### PR TITLE
Improve error handling for failed submissions

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -864,6 +864,7 @@ export const html = `
             } catch (error) {
                 console.error('Submit error:', error);
                 showToast(error.message || 'Failed to save note', 'error');
+                // Keep the text in the form when error occurs (text is NOT cleared)
             } finally {
                 // Reset submit button
                 submitBtn.textContent = '📝 Submit';

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,20 @@ async function handleSend(request: Request, ctx: ExecutionContext, corsHeaders: 
       });
     }
 
+    if (error instanceof WorkflowyAPIError) {
+      console.error('Workflowy API Error:', error.message, error.status);
+      return new Response(JSON.stringify({
+        error: error.message || 'Workflowy API error',
+        status: error.status,
+      }), {
+        status: 422, // Unprocessable Entity
+        headers: {
+          'Content-Type': 'application/json',
+          ...corsHeaders,
+        },
+      });
+    }
+
     return new Response(JSON.stringify({
       error: 'Internal server error',
     }), {
@@ -184,6 +198,7 @@ async function processNoteCreation(data: z.infer<typeof requestSchema>): Promise
       console.error('Workflowy API Error:', error.message, error.status);
     }
     
-    return {};
+    // Re-throw the error so it can be caught by handleSend
+    throw error;
   }
 }


### PR DESCRIPTION
## Summary
- Fixed Workflowy API errors being masked as success responses
- Added proper error propagation from backend to frontend
- Preserve user input when submission fails
- Show accurate error messages instead of false success notifications

## Changes
- Re-throw errors in processNoteCreation instead of returning empty object
- Add specific WorkflowyAPIError handling with 422 status code
- Keep text in form fields when errors occur
- Improved error messages for better user experience

## Test plan
- [ ] Test with invalid API key to verify error handling
- [ ] Test with invalid save location URL
- [ ] Verify that text remains in fields when submission fails
- [ ] Check that proper error messages are displayed

🤖 Generated with [Claude Code](https://claude.ai/code)