### PR TITLE
Improve history functionality with individual item deletion

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -592,7 +592,7 @@ export const html = `
     <div id="historyModal" class="modal">
         <div class="modal-content">
             <div class="modal-header">
-                <h2 class="modal-title">Post History</h2>
+                <h2 class="modal-title">Post History (up to 30)</h2>
                 <button class="close" id="historyClose">×</button>
             </div>
             <div class="modal-body">
@@ -666,6 +666,7 @@ export const html = `
         // Settings state
         let currentLocationIndex = localStorage.getItem('jotflowy_selectedLocation') || '';
         let timestampEnabled = localStorage.getItem('jotflowy_timestampEnabled') !== 'false';
+        const historyLimit = 30; // Fixed limit
 
         // Initialize app
         document.addEventListener('DOMContentLoaded', function() {
@@ -915,8 +916,8 @@ export const html = `
                         bulletUrl: responseData.new_bullet_url || null,
                     };
                     settings.history.unshift(historyItem);
-                    if (settings.history.length > 10) {
-                        settings.history = settings.history.slice(0, 10);
+                    if (settings.history.length > historyLimit) {
+                        settings.history = settings.history.slice(0, historyLimit);
                     }
                     saveSettings();
 
@@ -1019,6 +1020,7 @@ export const html = `
                     <div style="margin-top: 8px; display: flex; gap: 8px;">
                         <button onclick="loadFromHistory('\${item.id}')" style="background: var(--accent-color); color: white; border: none; padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 12px;">Load</button>
                         \${item.bulletUrl ? \`<a href="\${item.bulletUrl}" target="_blank" rel="noopener" style="background: var(--success-color); color: white; border: none; padding: 4px 8px; border-radius: 4px; text-decoration: none; cursor: pointer; font-size: 12px;">🔗 View</a>\` : ''}
+                        <button onclick="deleteHistoryItem('\${item.id}')" style="background: var(--error-color); color: white; border: none; padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 12px;">❌ Remove</button>
                     </div>
                 </div>
             \`).join('');
@@ -1040,6 +1042,15 @@ export const html = `
                 updateSubmitButtonState();
                 closeModal('historyModal');
                 showToast('Loaded from history', 'success');
+            }
+        }
+
+        function deleteHistoryItem(id) {
+            if (confirm('Remove from local history? (Workflowy post stays intact)')) {
+                settings.history = settings.history.filter(item => item.id !== id);
+                saveSettings();
+                updateHistoryModal();
+                showToast('Removed from history', 'success');
             }
         }
 


### PR DESCRIPTION
## Summary
- Added individual delete functionality for history items
- Improved user messaging to avoid confusion with Workflowy post deletion
- Increased history limit from 10 to 30 items
- Enhanced clarity in UI text and confirmation dialogs

## Changes
- **Individual Deletion**: Added "❌ Remove" button for each history item
- **Clear Messaging**: Changed button text and confirmation dialog to clarify local-only deletion
- **Increased Limit**: History now stores up to 30 items (was 10)
- **UI Improvements**: Added "up to 30" in modal title for transparency
- **Better UX**: Confirmation dialog explains Workflowy posts remain intact

## Test plan
- [ ] Test individual history item removal
- [ ] Verify Workflowy posts are not affected by local history removal
- [ ] Check that history limit works correctly at 30 items
- [ ] Test "Clear History" functionality still works
- [ ] Verify confirmation messages are clear and helpful

🤖 Generated with [Claude Code](https://claude.ai/code)