### PR TITLE
Use browser timezone instead of hardcoded Asia/Tokyo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Save locations are stored in your browser's local storage. You can configure:
 ### API Settings
 - **API Key**: Your Workflowy API key (stored securely in browser)
 - **Default Location**: Your preferred save location
-- **Timestamp Format**: YYYY-MM-DD HH:mm (Japan timezone)
+- **Timestamp Format**: YYYY-MM-DD HH:mm (local timezone)
 
 ## Development
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,7 +91,7 @@ export function sanitizeInput(input: string): string {
 export function formatTimestamp(includeDate: boolean = false): string {
   const now = new Date();
   const options: Intl.DateTimeFormatOptions = {
-    timeZone: 'Asia/Tokyo',
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,

--- a/src/workflowy.ts
+++ b/src/workflowy.ts
@@ -120,7 +120,7 @@ export function buildNoteWithTimestamp(note: string, includeTimestamp: boolean):
 
   const now = new Date();
   const timestamp = now.toLocaleString('sv-SE', {
-    timeZone: 'Asia/Tokyo',
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   }).slice(0, 16); // "2025-01-08 14:30"
 
   if (note.trim() === '') {


### PR DESCRIPTION
## Summary
- Replace hardcoded Asia/Tokyo timezone with automatic browser timezone detection
- Improve international usability while maintaining format consistency
- No breaking changes for existing users

## Problem Solved
The app was limited to Japanese users due to hardcoded `Asia/Tokyo` timezone in timestamp functions. International users would see incorrect local times in their notes.

## Changes Made

### 1. Automatic Timezone Detection
**Before:**
```javascript
timeZone: 'Asia/Tokyo'
```

**After:** 
```javascript
timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
```

### 2. Updated Functions
- `buildNoteWithTimestamp()` in `src/workflowy.ts:123`
- `formatTimestamp()` in `src/utils.ts:94`

### 3. Documentation Updates
- README updated to reflect "local timezone" instead of "Japan timezone"

## Benefits
- **International Support**: Works correctly for users worldwide
- **Automatic Detection**: No user configuration required
- **Respects System Settings**: Uses the user's configured timezone
- **Better UX**: Timestamps show the user's local time
- **Backward Compatible**: Japanese users continue to see JST timestamps

## Test Results
✅ Timezone detection working correctly
✅ Timestamp format maintained (YYYY-MM-DD HH:mm)  
✅ No breaking changes for existing functionality

## Examples
- **Japan user**: Still sees `2025-08-08 17:30` (JST)
- **US user**: Now sees `2025-08-08 04:30` (EST) instead of incorrect JST time
- **EU user**: Now sees `2025-08-08 10:30` (CET) instead of incorrect JST time

This enhancement makes Jotflowy truly international while maintaining the same experience for existing users.

🤖 Generated with [Claude Code](https://claude.ai/code)