### PR TITLE
Redesign history buttons to be less prominent

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -403,6 +403,7 @@ export const html = `
             font-weight: 500;
             color: var(--text-primary);
             margin-bottom: 4px;
+            font-size: 16px;
         }
 
         .history-item-meta {
@@ -1222,33 +1223,16 @@ export const html = `
                     <div class="history-item-meta">
                         \${item.location} • \${new Date(item.timestamp).toLocaleString('ja-JP')}
                     </div>
-                    <div style="margin-top: 8px; display: flex; gap: 8px;">
-                        <button onclick="loadFromHistory('\${item.id}')" style="background: var(--accent-color); color: white; border: none; padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 12px;">Load</button>
-                        \${item.bulletUrl ? \`<a href="\${item.bulletUrl}" target="_blank" rel="noopener" style="background: var(--success-color); color: white; border: none; padding: 4px 8px; border-radius: 4px; text-decoration: none; cursor: pointer; font-size: 12px;"><i class="fas fa-external-link-alt"></i> View</a>\` : ''}
-                        <button onclick="deleteHistoryItem('\${item.id}')" style="background: var(--error-color); color: white; border: none; padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 12px;"><i class="fas fa-trash-alt"></i> Remove</button>
+                    <div style="margin-top: 8px; display: flex; gap: 12px;">
+                        \${item.bulletUrl ? \`<a href="\${item.bulletUrl}" target="_blank" rel="noopener" style="background: none; color: #d8dee9; border: none; padding: 4px 0; text-decoration: none; cursor: pointer; font-size: 12px; display: flex; align-items: center; gap: 4px; transition: opacity 0.2s;" onmouseover="this.style.opacity='0.7'" onmouseout="this.style.opacity='1'"><i class="fas fa-external-link-alt"></i> View</a>\` : ''}
+                        <button onclick="deleteHistoryItem('\${item.id}')" style="background: none; color: #d08770; border: none; padding: 4px 0; cursor: pointer; font-size: 12px; display: flex; align-items: center; gap: 4px; transition: opacity 0.2s;" onmouseover="this.style.opacity='0.7'" onmouseout="this.style.opacity='1'">
+                            <i class="fas fa-trash-alt"></i> Remove
+                        </button>
                     </div>
                 </div>
             \`).join('');
         }
 
-        function loadFromHistory(id) {
-            const item = settings.history.find(h => h.id === id);
-            if (item) {
-                textArea.value = item.title;
-                noteArea.value = item.note || '';
-                
-                // Find matching location
-                const locationIndex = settings.locations.findIndex(l => l.name === item.location);
-                if (locationIndex >= 0) {
-                    currentLocationIndex = locationIndex.toString();
-                    safeSetItem('jotflowy_selectedLocation', currentLocationIndex);
-                }
-                
-                updateSubmitButtonState();
-                closeModal('historyModal');
-                showToast('Loaded from history', 'success');
-            }
-        }
 
         function deleteHistoryItem(id) {
             if (confirm('Remove from local history? (Workflowy post stays intact)')) {


### PR DESCRIPTION
## Summary
- Simplified history buttons to reduce visual distraction
- Removed Load functionality for cleaner UX
- Implemented consistent icon + text styling

## Changes
- **Removed colored backgrounds** from all history buttons
- **Removed Load button** and `loadFromHistory()` function entirely
- **Updated button styling**:
  - View: Nord white-gray (#d8dee9) with external link icon
  - Remove: Nord aurora orange (#d08770) with trash icon
- **Added subtle hover effects** with opacity transitions
- **Increased history item title font size** to 16px for better readability

## Test Plan
- [x] Verified buttons display correctly with new styling
- [x] Confirmed View links work properly
- [x] Confirmed Remove functionality works as expected
- [x] Tested hover effects
- [x] Verified improved readability with larger title font

The history UI is now less visually overwhelming while maintaining all essential functionality.

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)