### PR TITLE
fix: Preserve editor content when switching destination

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,15 @@
 {
   "hooks": {
-    "bash-pre": {
-      "command": "echo 'Running pre-commit checks...' && npm run test:run && npm run typecheck && echo 'All checks passed!'",
-      "on": ["git commit*"]
-    }
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git commit*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Running pre-commit checks...' && npm run test:run && npm run typecheck && echo 'All checks passed!'"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/public/scripts/client.js
+++ b/public/scripts/client.js
@@ -172,7 +172,6 @@ function toggleDestinationDropdown() {
       saveSettings();
       updateDestinationLabel();
       destinationDropdown.classList.add("hidden");
-      editor.value = "";
         });
     destinationDropdown.appendChild(item);
   }
@@ -604,7 +603,6 @@ function renderDestinationList() {
       saveSettings();
       updateDestinationLabel();
       renderDestinationList();
-      editor.value = "";
         });
     div.querySelector(".destination-item-delete").addEventListener("click", (e) => {
       e.stopPropagation();


### PR DESCRIPTION
## Summary
- Remove `editor.value = ""` from destination change handlers
- Editor content is now preserved when switching between destinations in both the dropdown and the settings modal

## Changes
- `public/scripts/client.js`: Remove two explicit editor clear calls that fired on destination selection

## Test Plan
- Open the app and type some text in the editor
- Switch to a different destination using the dropdown
- Verify the editor content remains intact
- Open settings modal, switch destination, verify content still remains