### PR TITLE
style: modernize UI with flat design and Iconify heroicons

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -103,20 +103,19 @@ html, body {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: var(--bg-light);
-  border: 1px solid var(--border);
+  background: transparent;
+  border: none;
   border-radius: var(--radius);
   color: var(--text-muted);
   padding: 6px 10px;
   font-size: 13px;
   cursor: pointer;
   max-width: 100%;
-  transition: border-color 0.15s, background 0.15s;
+  transition: background 0.15s;
 }
 
 .destination-selector:hover {
-  border-color: var(--accent);
-  background: var(--bg-lighter);
+  background: var(--bg-light);
 }
 
 .destination-icon {
@@ -140,7 +139,7 @@ html, body {
   bottom: calc(100% + 6px);
   left: 0;
   background: var(--bg-light);
-  border: 1px solid var(--border);
+  border: none;
   border-radius: var(--radius);
   min-width: 200px;
   max-width: 300px;
@@ -192,9 +191,9 @@ html, body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-light);
+  background: transparent;
   color: var(--text-muted);
-  border: 1px solid var(--border);
+  border: none;
   border-radius: var(--radius);
   padding: 8px;
   cursor: pointer;
@@ -202,7 +201,7 @@ html, body {
 }
 
 .btn:hover {
-  background: var(--bg-lighter);
+  background: var(--bg-light);
   color: var(--text);
 }
 
@@ -213,7 +212,6 @@ html, body {
 .btn-send {
   background: var(--accent);
   color: var(--nord6);
-  border-color: var(--accent);
   padding: 8px 16px;
   font-weight: 600;
   gap: 6px;
@@ -221,7 +219,6 @@ html, body {
 
 .btn-send:hover {
   background: var(--accent-hover);
-  border-color: var(--accent-hover);
 }
 
 .btn-send:disabled {
@@ -237,13 +234,11 @@ html, body {
 .btn-primary {
   background: var(--accent);
   color: var(--nord6);
-  border-color: var(--accent);
 }
 
 .btn-danger {
   color: var(--nord6);
   background: var(--danger);
-  border-color: var(--danger);
 }
 
 .btn-danger:hover {

--- a/src/components/layouts/BaseLayout.tsx
+++ b/src/components/layouts/BaseLayout.tsx
@@ -14,6 +14,7 @@ export const BaseLayout: FC<PropsWithChildren<{ title?: string }>> = ({ children
     </head>
     <body>
       {children}
+      <script src="https://cdn.jsdelivr.net/npm/iconify-icon@2/dist/iconify-icon.min.js"></script>
       <script src="/scripts/client.js" type="module"></script>
     </body>
   </html>

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -14,33 +14,21 @@ export const MainPage: FC = () => (
     <footer class="toolbar">
       <div class="toolbar-left">
         <button id="destination-selector" class="destination-selector" title="Change destination">
-          <svg class="destination-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M5 3l14 9-14 9V3z" />
-          </svg>
+          <iconify-icon class="destination-icon" icon="heroicons:map-pin" width="12" height="12"></iconify-icon>
           <span id="destination-label">No destination</span>
-          <svg class="destination-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <polyline points="6 9 12 15 18 9" />
-          </svg>
+          <iconify-icon class="destination-chevron" icon="heroicons:chevron-down" width="12" height="12"></iconify-icon>
         </button>
         <div id="destination-dropdown" class="destination-dropdown hidden"></div>
       </div>
       <div class="toolbar-right">
         <button id="btn-settings" class="btn" title="Settings">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="3" />
-            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-          </svg>
+          <iconify-icon icon="heroicons:cog-6-tooth" width="20" height="20"></iconify-icon>
         </button>
         <button id="btn-history" class="btn" title="History">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="10" />
-            <polyline points="12 6 12 12 16 14" />
-          </svg>
+          <iconify-icon icon="heroicons:clock" width="20" height="20"></iconify-icon>
         </button>
         <button id="btn-send" class="btn btn-send" title="Send">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" />
-          </svg>
+          <iconify-icon icon="heroicons:paper-airplane" width="16" height="16"></iconify-icon>
           Send
         </button>
       </div>


### PR DESCRIPTION
## Summary

- Remove borders from `.btn` and `.destination-selector` for a flat design
- Use `transparent` background on buttons (show background only on hover)
- Replace inline SVG icons with Iconify web components using Heroicons outline set

## Changes

- `public/styles/main.css`: Remove `border` from `.btn`, `.destination-selector`, `.destination-dropdown`; set `background: transparent` on buttons
- `src/components/layouts/BaseLayout.tsx`: Add Iconify CDN script
- `src/components/pages/MainPage.tsx`: Replace all inline SVG icons with `<iconify-icon>` elements

## Test Plan

- [ ] Hard reload and verify buttons have no border
- [ ] Verify hover state shows background on buttons
- [ ] Verify all icons render correctly (settings, history, send, destination pin, chevron)

Closes #43