### PR TITLE
chore: Update CI workflows with SHA pinning, .yaml extension, and dev env fix

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,7 @@ name: Deploy to Cloudflare Workers
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -10,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '20'
         cache: 'npm'
@@ -25,7 +26,7 @@ jobs:
       run: npm run typecheck
 
     - name: Deploy to Cloudflare Workers
-      uses: cloudflare/wrangler-action@v3
+      uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 .local/
 
 # Environment files
+.dev.vars
 .env
 .env.local
 .env.production

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,9 +2,5 @@ name = "jotflowy"
 main = "src/index.tsx"
 compatibility_date = "2024-01-17"
 
-[vars]
-ENCRYPTION_KEY = "dev-key-change-in-production-abcdef123456"
-ALLOWED_ORIGINS = "http://localhost:8787"
-
 [assets]
 directory = "./public"


### PR DESCRIPTION
## Summary

- Rename workflow files from `.yml` to `.yaml` for consistency
- Update all GitHub Actions to latest versions with SHA pinning
- Add `workflow_dispatch` trigger to deploy workflow for manual runs
- Fix deploy error caused by duplicate env var binding (code 10053)

## Changes

- `.github/workflows/deploy.yaml`: Rename, add `workflow_dispatch`, pin actions to SHA
- `.github/workflows/test.yaml`: Rename, pin actions to SHA
- `wrangler.toml`: Remove `[vars]` block (was conflicting with GHA secrets)
- `.gitignore`: Add `.dev.vars`
- `.dev.vars`: Local dev environment variables (not committed)

### Action versions

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6.0.2 (SHA pinned) |
| actions/setup-node | v4 | v6.4.0 (SHA pinned) |
| cloudflare/wrangler-action | v3 | v3.15.0 (SHA pinned) |

## Test Plan

- [ ] Verify deploy workflow runs on push to main
- [ ] Verify deploy workflow can be triggered manually via `workflow_dispatch`
- [ ] Verify local `npm run dev` works with `.dev.vars`