### PR TITLE
fix: Remove secrets block from wrangler-action to fix deploy error

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,9 +30,3 @@ jobs:
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        secrets: |
-          ENCRYPTION_KEY
-          ALLOWED_ORIGINS
-      env:
-        ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
-        ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}


### PR DESCRIPTION
## Summary

- Remove `secrets` and `env` blocks from wrangler-action in deploy workflow
- Fixes deploy error code 10053 (binding name already in use)

## Changes

- `.github/workflows/deploy.yaml`: Remove `ENCRYPTION_KEY` and `ALLOWED_ORIGINS` from wrangler-action secrets — both are already managed in Cloudflare dashboard

## Test Plan

- [x] Verified via `workflow_dispatch` that deploy succeeds without the secrets block