### PR TITLE
feat(ui): Add typography settings with sliders and font family selector

### DIFF
--- a/public/scripts/client.js
+++ b/public/scripts/client.js
@@ -1,4 +1,4 @@
-import { applyTemplate, parseContent, escapeRegex, escapeHtml, stripHtml } from "./utils.js";
+import { applyTemplate, parseContent, escapeRegex, escapeHtml, stripHtml, applyTypographySettings, FONT_FAMILY_MAP } from "./utils.js";
 
 // State
 let settings = loadSettings();
@@ -16,6 +16,11 @@ const toast = document.getElementById("toast");
 
 // Settings modal
 const modalSettings = document.getElementById("modal-settings");
+const fontSizeSlider = document.getElementById("font-size-slider");
+const fontSizeValue = document.getElementById("font-size-value");
+const lineHeightSlider = document.getElementById("line-height-slider");
+const lineHeightValue = document.getElementById("line-height-value");
+const fontFamilySelect = document.getElementById("font-family-select");
 const apiKeyInput = document.getElementById("api-key-input");
 const btnSaveApikey = document.getElementById("btn-save-apikey");
 const btnClearApikey = document.getElementById("btn-clear-apikey");
@@ -40,6 +45,7 @@ let selectedNodeId = null;
 
 // Init
 async function init() {
+  applyTypographySettings(settings);
   updateDestinationLabel();
   handleShareTarget();
   registerServiceWorker();
@@ -66,7 +72,36 @@ function bindEvents() {
   btnSettings.addEventListener("click", () => {
     updateApiKeyUI();
     renderDestinationList();
+    const fs = settings.fontSize ?? 16;
+    const lh = settings.lineHeight ?? 1.8;
+    fontSizeSlider.value = String(fs);
+    fontSizeValue.textContent = `${fs}px`;
+    lineHeightSlider.value = String(lh);
+    lineHeightValue.textContent = String(lh);
+    fontFamilySelect.value = settings.fontFamily || "gothic";
     openModal(modalSettings);
+  });
+
+  fontSizeSlider.addEventListener("input", (e) => {
+    const val = Number(e.target.value);
+    fontSizeValue.textContent = `${val}px`;
+    settings.fontSize = val;
+    saveSettings();
+    applyTypographySettings(settings);
+  });
+
+  lineHeightSlider.addEventListener("input", (e) => {
+    const val = Number(e.target.value);
+    lineHeightValue.textContent = String(val);
+    settings.lineHeight = val;
+    saveSettings();
+    applyTypographySettings(settings);
+  });
+
+  fontFamilySelect.addEventListener("change", (e) => {
+    settings.fontFamily = e.target.value;
+    saveSettings();
+    applyTypographySettings(settings);
   });
 
   // Destination selector dropdown
@@ -184,7 +219,7 @@ function loadSettings() {
     const raw = localStorage.getItem("jotflowy_settings");
     if (raw) return JSON.parse(raw);
   } catch {}
-  return { destinations: [], selectedDestinationId: "" };
+  return { destinations: [], selectedDestinationId: "", fontSize: 16, lineHeight: 1.8, fontFamily: "gothic" };
 }
 
 function saveSettings() {

--- a/public/scripts/utils.d.ts
+++ b/public/scripts/utils.d.ts
@@ -3,3 +3,5 @@ export function parseContent(text: string): { name: string; note: string | undef
 export function escapeRegex(str: string): string;
 export function escapeHtml(str: string): string;
 export function stripHtml(html: string): string;
+export const FONT_FAMILY_MAP: Record<string, string>;
+export function applyTypographySettings(settings: { fontSize?: number; lineHeight?: number; fontFamily?: string }): void;

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -42,3 +42,18 @@ export function stripHtml(html) {
   div.innerHTML = html;
   return div.textContent || "";
 }
+
+export const FONT_FAMILY_MAP = {
+  gothic: '"Yu Gothic", "游ゴシック", YuGothic, "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Noto Sans CJK JP", "Noto Sans JP", -apple-system, BlinkMacSystemFont, sans-serif',
+  hiragino: '"Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", "游ゴシック", YuGothic, "Noto Sans CJK JP", "Noto Sans JP", -apple-system, BlinkMacSystemFont, sans-serif',
+  mincho: '"Yu Mincho", "游明朝", YuMincho, "Hiragino Mincho ProN", "Noto Serif CJK JP", serif',
+};
+
+export function applyTypographySettings(settings) {
+  const fontSize = settings.fontSize ?? 16;
+  const lineHeight = settings.lineHeight ?? 1.8;
+  const fontFamily = FONT_FAMILY_MAP[settings.fontFamily] ?? FONT_FAMILY_MAP.gothic;
+  document.documentElement.style.setProperty("--font-size", `${fontSize}px`);
+  document.documentElement.style.setProperty("--line-height", String(lineHeight));
+  document.documentElement.style.setProperty("--font-family", fontFamily);
+}

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -313,9 +313,39 @@ html, body {
 
 /* Settings */
 .settings-section {
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+
+.settings-section:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.settings-summary {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.settings-summary::-webkit-details-marker {
+  display: none;
+}
+
+.settings-summary::before {
+  content: "›";
+  font-size: 22px;
+  line-height: 1;
+  color: var(--text-muted);
+  transition: transform 0.15s ease;
+  display: inline-block;
+}
+
+.settings-section[open] .settings-summary::before {
+  transform: rotate(90deg);
 }
 
 .settings-section h3 {
@@ -324,6 +354,13 @@ html, body {
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
+}
+
+.settings-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
 }
 
 .input-group {

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -34,6 +34,9 @@
   --warning: var(--nord13);
   --border: var(--nord3);
   --radius: 8px;
+  --font-size: 16px;
+  --line-height: 1.8;
+  --font-family: "Yu Gothic", "游ゴシック", YuGothic, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
 * {
@@ -46,8 +49,8 @@ html, body {
   height: 100%;
   background: var(--bg);
   color: var(--text);
-  font-family: "Yu Gothic", "游ゴシック", YuGothic, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  font-size: 16px;
+  font-family: var(--font-family);
+  font-size: var(--font-size);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -72,8 +75,8 @@ html, body {
   border: none;
   outline: none;
   color: var(--text);
-  font-size: 16px;
-  line-height: 1.8;
+  font-size: var(--font-size);
+  line-height: var(--line-height);
   resize: none;
   font-family: inherit;
 }
@@ -354,6 +357,73 @@ html, body {
   background: var(--bg-secondary);
   color: var(--text-muted);
   cursor: not-allowed;
+}
+
+.select {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 8px 12px;
+  font-size: 14px;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+}
+
+.select:focus {
+  border-color: var(--accent);
+}
+
+.slider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.slider-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.slider-value {
+  font-size: 12px;
+  color: var(--text-muted);
+  min-width: 36px;
+  text-align: right;
+}
+
+.slider {
+  width: 100%;
+  height: 4px;
+  background: var(--bg-lighter);
+  border-radius: 2px;
+  outline: none;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+}
+
+.slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  border: none;
 }
 
 .checkbox-group {

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -43,79 +43,85 @@ export const MainPage: FC = () => (
           <button class="modal-close" data-close-modal="modal-settings">&times;</button>
         </div>
         <div class="modal-body">
-          <section class="settings-section">
-            <h3>API Key</h3>
-            <div class="input-group">
-              <input id="api-key-input" type="password" placeholder="Workflowy API Key" class="input" />
-              <button id="btn-save-apikey" class="btn btn-small btn-primary">Save</button>
-              <button id="btn-clear-apikey" class="btn btn-small hidden">Clear</button>
-              <button id="btn-edit-apikey" class="btn btn-small hidden">Edit</button>
-            </div>
-            <p class="text-muted text-small">
-              <a href="https://workflowy.com/api-key" target="_blank" rel="noopener">Get your API key</a>
-            </p>
-            <p class="text-muted text-small">
-              WARN: Your API key and data are processed by this server. <a href="https://github.com/chroju/jotflowy" target="_blank" rel="noopener">Deploy your own</a> for full privacy.
-            </p>
-          </section>
-
-          <section class="settings-section">
-            <h3>Destinations</h3>
-            <div id="destination-list" class="destination-list"></div>
-            <button id="btn-add-destination" class="btn btn-small">+ Add destination</button>
-          </section>
-
-          <section class="settings-section">
-            <h3>Typography</h3>
-            <div class="slider-group">
-              <div class="slider-header">
-                <label class="input-label" for="font-size-slider">Font Size</label>
-                <span id="font-size-value" class="slider-value">16px</span>
+          <details class="settings-section">
+            <summary class="settings-summary"><h3>API Key</h3></summary>
+            <div class="settings-content">
+              <div class="input-group">
+                <input id="api-key-input" type="password" placeholder="Workflowy API Key" class="input" />
+                <button id="btn-save-apikey" class="btn btn-small btn-primary">Save</button>
+                <button id="btn-clear-apikey" class="btn btn-small hidden">Clear</button>
+                <button id="btn-edit-apikey" class="btn btn-small hidden">Edit</button>
               </div>
-              <input id="font-size-slider" class="slider" type="range" min="12" max="24" step="1" value="16" />
+              <p class="text-muted text-small">
+                <a href="https://workflowy.com/api-key" target="_blank" rel="noopener">Get your API key</a>
+              </p>
+              <p class="text-muted text-small">
+                WARN: Your API key and data are processed by this server. <a href="https://github.com/chroju/jotflowy" target="_blank" rel="noopener">Deploy your own</a> for full privacy.
+              </p>
             </div>
-            <div class="slider-group">
-              <div class="slider-header">
-                <label class="input-label" for="line-height-slider">Line Height</label>
-                <span id="line-height-value" class="slider-value">1.8</span>
-              </div>
-              <input id="line-height-slider" class="slider" type="range" min="1.2" max="2.4" step="0.1" value="1.8" />
-            </div>
-            <div class="input-group">
-              <label class="input-label" for="font-family-select">Font Family</label>
-              <select id="font-family-select" class="select">
-                <option value="gothic">游ゴシック (Gothic)</option>
-                <option value="hiragino">ヒラギノ角ゴ (Gothic)</option>
-                <option value="mincho">游明朝 (Mincho)</option>
-              </select>
-            </div>
-          </section>
+          </details>
 
-          {/* Add destination sub-panel */}
-          <div id="panel-add-destination" class="sub-panel hidden">
-            <h3>Add Destination</h3>
-            <div id="node-tree" class="node-tree">
-              <p class="text-muted">Loading nodes...</p>
+          <details class="settings-section">
+            <summary class="settings-summary"><h3>Typography</h3></summary>
+            <div class="settings-content">
+              <div class="slider-group">
+                <div class="slider-header">
+                  <label class="input-label" for="font-size-slider">Font Size</label>
+                  <span id="font-size-value" class="slider-value">16px</span>
+                </div>
+                <input id="font-size-slider" class="slider" type="range" min="12" max="24" step="1" value="16" />
+              </div>
+              <div class="slider-group">
+                <div class="slider-header">
+                  <label class="input-label" for="line-height-slider">Line Height</label>
+                  <span id="line-height-value" class="slider-value">1.8</span>
+                </div>
+                <input id="line-height-slider" class="slider" type="range" min="1.2" max="2.4" step="0.1" value="1.8" />
+              </div>
+              <div class="input-group">
+                <label class="input-label" for="font-family-select">Font Family</label>
+                <select id="font-family-select" class="select">
+                  <option value="gothic">游ゴシック (Gothic)</option>
+                  <option value="hiragino">ヒラギノ角ゴ (Gothic)</option>
+                  <option value="mincho">游明朝 (Mincho)</option>
+                </select>
+              </div>
             </div>
-            <div class="input-group">
-              <input id="dest-name-input" type="text" placeholder="Display name" class="input" />
+          </details>
+
+          <details class="settings-section">
+            <summary class="settings-summary"><h3>Destinations</h3></summary>
+            <div class="settings-content">
+              <div id="destination-list" class="destination-list"></div>
+              <button id="btn-add-destination" class="btn btn-small">+ Add destination</button>
+
+              {/* Add destination sub-panel */}
+              <div id="panel-add-destination" class="sub-panel hidden">
+                <h3>Add Destination</h3>
+                <div id="node-tree" class="node-tree">
+                  <p class="text-muted">Loading nodes...</p>
+                </div>
+                <div class="input-group">
+                  <input id="dest-name-input" type="text" placeholder="Display name" class="input" />
+                </div>
+                <div class="checkbox-group">
+                  <label>
+                    <input id="dest-daily-note" type="checkbox" />
+                    Enable Daily Note
+                  </label>
+                </div>
+                <div class="input-group">
+                  <label class="input-label">Template</label>
+                  <input id="dest-default-text" type="text" placeholder={'e.g. **{HH}:{mm}** {content}'} class="input" />
+                  <p class="text-muted text-small">{'{content} = input text. Date: {YYYY}, {MM}, {DD}, {HH}, {mm}, {ss}'}</p>
+                </div>
+                <div class="btn-group">
+                  <button id="btn-save-destination" class="btn btn-primary btn-small">Save</button>
+                  <button id="btn-cancel-destination" class="btn btn-small">Cancel</button>
+                </div>
+              </div>
             </div>
-            <div class="checkbox-group">
-              <label>
-                <input id="dest-daily-note" type="checkbox" />
-                Enable Daily Note
-              </label>
-            </div>
-            <div class="input-group">
-              <label class="input-label">Template</label>
-              <input id="dest-default-text" type="text" placeholder={'e.g. **{HH}:{mm}** {content}'} class="input" />
-              <p class="text-muted text-small">{'{content} = input text. Date: {YYYY}, {MM}, {DD}, {HH}, {mm}, {ss}'}</p>
-            </div>
-            <div class="btn-group">
-              <button id="btn-save-destination" class="btn btn-primary btn-small">Save</button>
-              <button id="btn-cancel-destination" class="btn btn-small">Cancel</button>
-            </div>
-          </div>
+          </details>
         </div>
       </div>
     </div>

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -65,6 +65,32 @@ export const MainPage: FC = () => (
             <button id="btn-add-destination" class="btn btn-small">+ Add destination</button>
           </section>
 
+          <section class="settings-section">
+            <h3>Typography</h3>
+            <div class="slider-group">
+              <div class="slider-header">
+                <label class="input-label" for="font-size-slider">Font Size</label>
+                <span id="font-size-value" class="slider-value">16px</span>
+              </div>
+              <input id="font-size-slider" class="slider" type="range" min="12" max="24" step="1" value="16" />
+            </div>
+            <div class="slider-group">
+              <div class="slider-header">
+                <label class="input-label" for="line-height-slider">Line Height</label>
+                <span id="line-height-value" class="slider-value">1.8</span>
+              </div>
+              <input id="line-height-slider" class="slider" type="range" min="1.2" max="2.4" step="0.1" value="1.8" />
+            </div>
+            <div class="input-group">
+              <label class="input-label" for="font-family-select">Font Family</label>
+              <select id="font-family-select" class="select">
+                <option value="gothic">游ゴシック (Gothic)</option>
+                <option value="hiragino">ヒラギノ角ゴ (Gothic)</option>
+                <option value="mincho">游明朝 (Mincho)</option>
+              </select>
+            </div>
+          </section>
+
           {/* Add destination sub-panel */}
           <div id="panel-add-destination" class="sub-panel hidden">
             <h3>Add Destination</h3>

--- a/src/test/typography.test.ts
+++ b/src/test/typography.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+const { FONT_FAMILY_MAP, applyTypographySettings } = await import(
+  "../../public/scripts/utils.js"
+);
+
+describe("FONT_FAMILY_MAP", () => {
+  it("has gothic entry", () => {
+    expect(FONT_FAMILY_MAP["gothic"]).toBeDefined();
+    expect(typeof FONT_FAMILY_MAP["gothic"]).toBe("string");
+  });
+
+  it("has hiragino entry", () => {
+    expect(FONT_FAMILY_MAP["hiragino"]).toBeDefined();
+    expect(FONT_FAMILY_MAP["hiragino"]).toContain("Hiragino");
+  });
+
+  it("has mincho entry", () => {
+    expect(FONT_FAMILY_MAP["mincho"]).toBeDefined();
+    expect(FONT_FAMILY_MAP["mincho"]).toContain("serif");
+  });
+});
+
+describe("applyTypographySettings", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sets CSS variables for default settings", () => {
+    const spy = vi.spyOn(document.documentElement.style, "setProperty");
+    applyTypographySettings({ fontSize: 16, lineHeight: 1.8, fontFamily: "gothic" });
+    expect(spy).toHaveBeenCalledWith("--font-size", "16px");
+    expect(spy).toHaveBeenCalledWith("--line-height", "1.8");
+    expect(spy).toHaveBeenCalledWith("--font-family", expect.any(String));
+  });
+
+  it("sets numeric font size correctly", () => {
+    const spy = vi.spyOn(document.documentElement.style, "setProperty");
+    applyTypographySettings({ fontSize: 20, lineHeight: 1.8, fontFamily: "gothic" });
+    expect(spy).toHaveBeenCalledWith("--font-size", "20px");
+  });
+
+  it("sets numeric line height correctly", () => {
+    const spy = vi.spyOn(document.documentElement.style, "setProperty");
+    applyTypographySettings({ fontSize: 16, lineHeight: 2.2, fontFamily: "gothic" });
+    expect(spy).toHaveBeenCalledWith("--line-height", "2.2");
+  });
+
+  it("uses default values when settings are undefined", () => {
+    const spy = vi.spyOn(document.documentElement.style, "setProperty");
+    applyTypographySettings({});
+    expect(spy).toHaveBeenCalledWith("--font-size", "16px");
+    expect(spy).toHaveBeenCalledWith("--line-height", "1.8");
+  });
+});


### PR DESCRIPTION
## Summary

- フォントサイズ・行間・フォントファミリーをユーザーが設定モーダルから変更できるようにする
- フォントサイズ・行間はスライダーUI（リアルタイムで値表示）
- フォントファミリーは游ゴシック / ヒラギノ角ゴ / 游明朝の3択
- 設定はLocalStorageに保存され、ページリロード後も維持される

## Changes

- `public/scripts/utils.js`: `FONT_FAMILY_MAP` と `applyTypographySettings()` を追加
- `public/styles/main.css`: CSS変数（`--font-size`, `--line-height`, `--font-family`）を追加、スライダー／セレクターのスタイルを追加
- `src/components/pages/MainPage.tsx`: 設定モーダルにTypographyセクションを追加
- `public/scripts/client.js`: 設定の読み込み・保存・CSS変数適用のロジックを追加
- `src/test/typography.test.ts`: `FONT_FAMILY_MAP` と `applyTypographySettings()` のユニットテストを追加

## Test Plan

- [ ] `npm run test:run` で全テストがパスすること
- [ ] 設定モーダルにFont Size / Line Height のスライダーとFont Familyのセレクターが表示されること
- [ ] スライダー操作でエディターのフォントサイズ・行間がリアルタイムで変わること
- [ ] フォントファミリー変更が即座に反映されること
- [ ] ページリロード後も設定が維持されること

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)