### PR TITLE
feat: ヒストリーモーダルの改善（ページング・削除・リンクレンダリング）

### DIFF
--- a/public/scripts/client.js
+++ b/public/scripts/client.js
@@ -1,4 +1,4 @@
-import { applyTemplate, parseContent, escapeRegex, escapeHtml, stripHtml, applyTypographySettings, FONT_FAMILY_MAP } from "./utils.js";
+import { applyTemplate, parseContent, escapeRegex, escapeHtml, stripHtml, sanitizeHtml, applyTypographySettings, FONT_FAMILY_MAP } from "./utils.js";
 
 // State
 let settings = loadSettings();
@@ -409,7 +409,9 @@ async function loadHistory(limit = 7, append = false) {
       if (!group.items.length) continue;
       html += group.items
         .map((node) => {
-          const text = stripHtml(node.name || "").slice(0, 100);
+          const rawName = node.name || "";
+          const textContent = stripHtml(rawName);
+          const text = textContent.length > 100 ? sanitizeHtml(stripHtml(rawName).slice(0, 100)) : sanitizeHtml(rawName);
           const note = node.note ? stripHtml(node.note) : "";
           const wfUrl = `https://workflowy.com/#/${node.id}`;
           const isCompleted = node.completedAt !== null;
@@ -445,7 +447,7 @@ async function loadHistory(limit = 7, append = false) {
             <div class="history-item${completedClass}" data-node-id="${node.id}">
               ${toggleBtn}
               <div class="history-item-content">
-                <div class="history-item-text">${escapeHtml(text)}</div>
+                <div class="history-item-text">${text}</div>
                 ${noteHtml}
               </div>
               ${completeBtn}

--- a/public/scripts/utils.d.ts
+++ b/public/scripts/utils.d.ts
@@ -3,5 +3,6 @@ export function parseContent(text: string): { name: string; note: string | undef
 export function escapeRegex(str: string): string;
 export function escapeHtml(str: string): string;
 export function stripHtml(html: string): string;
+export function sanitizeHtml(html: string): string;
 export const FONT_FAMILY_MAP: Record<string, string>;
 export function applyTypographySettings(settings: { fontSize?: number; lineHeight?: number; fontFamily?: string }): void;

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -43,6 +43,39 @@ export function stripHtml(html) {
   return div.textContent || "";
 }
 
+// Sanitize HTML: allow only <a> tags with safe href (http/https), strip everything else
+export function sanitizeHtml(html) {
+  const div = document.createElement("div");
+  div.innerHTML = html;
+
+  const walk = (node) => {
+    const children = Array.from(node.childNodes);
+    for (const child of children) {
+      if (child.nodeType === Node.TEXT_NODE) continue;
+      if (child.nodeType === Node.ELEMENT_NODE && child.tagName === "A") {
+        const href = child.getAttribute("href") || "";
+        if (/^https?:\/\//i.test(href)) {
+          // Keep only href, add safe attributes
+          const safe = document.createElement("a");
+          safe.href = href;
+          safe.target = "_blank";
+          safe.rel = "noopener noreferrer";
+          safe.textContent = child.textContent;
+          child.replaceWith(safe);
+        } else {
+          child.replaceWith(document.createTextNode(child.textContent));
+        }
+      } else {
+        // Replace non-<a> elements with their text content
+        child.replaceWith(document.createTextNode(child.textContent));
+      }
+    }
+  };
+
+  walk(div);
+  return div.innerHTML;
+}
+
 export const FONT_FAMILY_MAP = {
   gothic: '"Yu Gothic", "游ゴシック", YuGothic, "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Noto Sans CJK JP", "Noto Sans JP", -apple-system, BlinkMacSystemFont, sans-serif',
   hiragino: '"Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", "游ゴシック", YuGothic, "Noto Sans CJK JP", "Noto Sans JP", -apple-system, BlinkMacSystemFont, sans-serif',

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 
 // Import utils - we'll need to handle ES modules
 // Since utils.js uses DOM APIs, we need jsdom environment (configured in vitest.config.ts)
-const { applyTemplate, parseContent, escapeRegex, escapeHtml, stripHtml } = await import(
+const { applyTemplate, parseContent, escapeRegex, escapeHtml, stripHtml, sanitizeHtml } = await import(
   "../../public/scripts/utils.js"
 );
 
@@ -117,5 +117,39 @@ describe("stripHtml", () => {
 
   it("handles empty string", () => {
     expect(stripHtml("")).toBe("");
+  });
+});
+
+describe("sanitizeHtml", () => {
+  it("preserves <a> tags with href", () => {
+    expect(sanitizeHtml('<a href="https://example.com">link</a>')).toBe(
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a>'
+    );
+  });
+
+  it("strips non-<a> tags but keeps text", () => {
+    expect(sanitizeHtml("<b>bold</b>")).toBe("bold");
+    expect(sanitizeHtml("<script>alert(1)</script>")).toBe("alert(1)");
+  });
+
+  it("strips dangerous attributes from <a> tags", () => {
+    expect(sanitizeHtml('<a href="javascript:alert(1)">bad</a>')).toBe("bad");
+    expect(sanitizeHtml('<a href="https://example.com" onclick="evil()">link</a>')).toBe(
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a>'
+    );
+  });
+
+  it("handles mixed content", () => {
+    expect(sanitizeHtml('text <a href="https://example.com">link</a> more text')).toBe(
+      'text <a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a> more text'
+    );
+  });
+
+  it("handles plain text", () => {
+    expect(sanitizeHtml("plain text")).toBe("plain text");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeHtml("")).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

- `/history` APIに `limit` パラメータを追加し、取得件数を動的に制御できるようにした
- 空の子ノードを持つ日付グループをAPIレスポンスから除外するようにした
- ヒストリーモーダルに「Load more」ボタンを追加し、追加取得・追記表示を実装した
- ヒストリーアイテムおよび日付グループに削除ボタンを追加し、`DELETE /nodes/:id` エンドポイントを実装した
- ヒストリーアイテムのテキスト内リンクをクリッカブルなアンカータグとしてレンダリングするよう変更した（`sanitizeHtml` によるXSS対策付き）

## Changes

- `src/api/handlers.ts`: `limit` クエリパラメータ対応、空子ノードフィルタリング、`DELETE /nodes/:id` 追加
- `src/api/workflowy-v1.ts`: `deleteNode` メソッド追加
- `public/scripts/client.js`: `loadHistory(limit, append)` のシグネチャ変更、Load moreボタン処理、削除ボタンのイベントハンドラ追加
- `public/scripts/utils.js`: `sanitizeHtml` 関数追加（`<a>` タグのみ許可、`javascript:` プロトコル除外）
- `src/components/pages/MainPage.tsx`: Load moreボタンのHTML追加
- `public/styles/main.css`: Load moreコンテナ・削除ボタンのスタイル追加
- `src/test/handlers.test.ts`: 新規テスト（`GET /api/history`、`DELETE /api/nodes/:id`）
- `src/test/utils.test.ts`: `sanitizeHtml` のテスト追加

## Test Plan

- `npm run test:run` でテストが全件パスすることを確認
- ヒストリーモーダルを開いて7件表示→「Load more」で追加取得されることを確認
- アイテム削除ボタンをクリックして該当アイテムが消えることを確認
- 日付グループの削除ボタンをクリックしてグループ全体が消えることを確認
- テキスト内URLがリンクとして表示されることを確認