### PR TITLE
feat: Historyをデフォルト画面にし、投稿フォームをモーダル化・Infinite Scroll対応

### DIFF
--- a/public/scripts/client.js
+++ b/public/scripts/client.js
@@ -7,7 +7,7 @@ let isAuthenticated = false;
 // DOM elements
 const editor = document.getElementById("editor");
 const btnSend = document.getElementById("btn-send");
-const btnHistory = document.getElementById("btn-history");
+const btnCompose = document.getElementById("btn-compose");
 const btnSettings = document.getElementById("btn-settings");
 const destinationSelector = document.getElementById("destination-selector");
 const destinationLabel = document.getElementById("destination-label");
@@ -21,8 +21,6 @@ const fontSizeValue = document.getElementById("font-size-value");
 const lineHeightSlider = document.getElementById("line-height-slider");
 const lineHeightValue = document.getElementById("line-height-value");
 const fontFamilySelect = document.getElementById("font-family-select");
-const historyLoadMore = document.getElementById("history-load-more");
-const btnLoadMore = document.getElementById("btn-load-more");
 const apiKeyInput = document.getElementById("api-key-input");
 const btnSaveApikey = document.getElementById("btn-save-apikey");
 const btnClearApikey = document.getElementById("btn-clear-apikey");
@@ -39,8 +37,10 @@ const destDefaultText = document.getElementById("dest-default-text");
 const btnSaveDestination = document.getElementById("btn-save-destination");
 const btnCancelDestination = document.getElementById("btn-cancel-destination");
 
-// History modal
-const modalHistory = document.getElementById("modal-history");
+// Compose modal
+const modalCompose = document.getElementById("modal-compose");
+
+// History
 const historyList = document.getElementById("history-list");
 
 let selectedNodeId = null;
@@ -54,6 +54,7 @@ async function init() {
   bindEvents();
   setupMobileViewport();
   await checkAuth();
+  loadHistory();
 }
 
 // Handle mobile keyboard viewport
@@ -70,12 +71,7 @@ function setupMobileViewport() {
 
 function bindEvents() {
   btnSend.addEventListener("click", handleSend);
-  btnHistory.addEventListener("click", () => openModal(modalHistory, () => loadHistory(7)));
-  btnLoadMore.addEventListener("click", () => {
-    const current = parseInt(btnLoadMore.dataset.currentLimit || "7", 10);
-    btnLoadMore.innerHTML = '<div class="spinner"></div>';
-    loadHistory(current + 7, true);
-  });
+  btnCompose.addEventListener("click", () => openModal(modalCompose, () => editor.focus()));
   btnSettings.addEventListener("click", () => {
     updateApiKeyUI();
     renderDestinationList();
@@ -214,7 +210,8 @@ function toggleDestinationDropdown() {
       saveSettings();
       updateDestinationLabel();
       destinationDropdown.classList.add("hidden");
-        });
+      loadHistory();
+    });
     destinationDropdown.appendChild(item);
   }
   destinationDropdown.classList.remove("hidden");
@@ -347,12 +344,165 @@ async function handleSend() {
     });
 
     editor.value = "";
+    modalCompose.classList.add("hidden");
     showToast("Sent!");
+    loadHistory();
   } catch (e) {
     showToast(e.message, true);
   } finally {
     btnSend.disabled = false;
   }
+}
+
+// History rendering
+let historyObserver = null;
+
+function setupInfiniteScroll(beforeDate) {
+  if (historyObserver) historyObserver.disconnect();
+
+  const sentinel = document.createElement("div");
+  sentinel.className = "history-sentinel";
+  historyList.appendChild(sentinel);
+
+  let loading = false;
+  historyObserver = new IntersectionObserver(async (entries) => {
+    if (!entries[0].isIntersecting || loading) return;
+    loading = true;
+    sentinel.innerHTML = '<div class="spinner"></div>';
+    try {
+      await loadMoreHistory(beforeDate);
+    } finally {
+      loading = false;
+    }
+  });
+  historyObserver.observe(sentinel);
+}
+
+async function loadMoreHistory(beforeDate) {
+  const dest = getSelectedDestination();
+  if (!dest || !dest.dailyNoteEnabled) return;
+
+  const sentinel = historyList.querySelector(".history-sentinel");
+  try {
+    const groups = await apiRequest(
+      `/history?parent_id=${encodeURIComponent(dest.nodeId)}&daily_note=true&before_date=${encodeURIComponent(beforeDate)}`
+    );
+    if (sentinel) sentinel.remove();
+    if (historyObserver) { historyObserver.disconnect(); historyObserver = null; }
+
+    if (!groups.length) return;
+
+    const trashIcon = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      <path d="M10 11v6M14 11v6" />
+      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+    </svg>`;
+
+    let html = "";
+    for (const group of groups) {
+      if (group.date) {
+        const dateWfUrl = group.dateId ? `https://workflowy.com/#/${group.dateId}` : null;
+        const dateText = escapeHtml(stripHtml(group.date));
+        const dateDeleteBtn = group.dateId
+          ? `<button class="history-date-delete" data-node-id="${group.dateId}" title="Delete date group">${trashIcon}</button>`
+          : "";
+        html += dateWfUrl
+          ? `<div class="history-date-header">
+              <span class="history-date-text">${dateText}</span>
+              <a href="${dateWfUrl}" target="_blank" class="history-date-link" title="Open in Workflowy">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                  <polyline points="15 3 21 3 21 9" />
+                  <line x1="10" y1="14" x2="21" y2="3" />
+                </svg>
+              </a>
+              ${dateDeleteBtn}
+            </div>`
+          : `<div class="history-date-header">${dateText}</div>`;
+      }
+      if (!group.items.length) continue;
+      html += group.items
+        .map((node) => {
+          const rawName = node.name || "";
+          const textContent = stripHtml(rawName);
+          const text = textContent.length > 100 ? sanitizeHtml(stripHtml(rawName).slice(0, 100)) : sanitizeHtml(rawName);
+          const note = node.note ? stripHtml(node.note) : "";
+          const wfUrl = `https://workflowy.com/#/${node.id}`;
+          const isCompleted = node.completedAt !== null;
+          const completedClass = isCompleted ? " completed" : "";
+          const hasNote = note.length > 0;
+
+          const toggleBtn = hasNote
+            ? `<button class="history-item-toggle" data-node-id="${node.id}" title="Toggle note">
+                <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor">
+                  <polygon points="2,0 8,5 2,10" />
+                </svg>
+              </button>`
+            : `<span class="history-item-toggle-spacer"></span>`;
+
+          const noteHtml = hasNote
+            ? `<div class="history-item-note hidden" data-note-for="${node.id}">${escapeHtml(note)}</div>`
+            : "";
+
+          const completeBtn = isCompleted
+            ? `<button class="history-item-uncomplete" data-node-id="${node.id}" title="Mark as incomplete">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M3 12a9 9 0 1 0 18 0 9 9 0 1 0 -18 0" />
+                  <path d="M9 12l2 2l4 -4" />
+                </svg>
+              </button>`
+            : `<button class="history-item-complete" data-node-id="${node.id}" title="Mark as complete">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="9" />
+                </svg>
+              </button>`;
+
+          return `
+            <div class="history-item${completedClass}" data-node-id="${node.id}">
+              ${toggleBtn}
+              <div class="history-item-content">
+                <div class="history-item-text">${text}</div>
+                ${noteHtml}
+              </div>
+              ${completeBtn}
+              <a href="${wfUrl}" target="_blank" class="history-item-link" title="Open in Workflowy">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                  <polyline points="15 3 21 3 21 9" />
+                  <line x1="10" y1="14" x2="21" y2="3" />
+                </svg>
+              </a>
+              <button class="history-item-delete" data-node-id="${node.id}" title="Delete">${trashIcon}</button>
+            </div>
+          `;
+        })
+        .join("");
+    }
+
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    historyList.append(...container.childNodes);
+
+    const last = groups[groups.length - 1];
+    if (last.hasMore) {
+      const nextBeforeDate = parseDateText(last.date || "");
+      if (nextBeforeDate) setupInfiniteScroll(nextBeforeDate);
+    }
+  } catch (e) {
+    if (sentinel) sentinel.innerHTML = `<p class="text-muted">${escapeHtml(e.message)}</p>`;
+  }
+}
+
+function parseDateText(text) {
+  const bracketMatch = text.match(/\[(\d{4}-\d{2}-\d{2})\]/);
+  if (bracketMatch) return bracketMatch[1];
+  const wfMatch = text.match(/\w{3}, (\w{3}) (\d{1,2}), (\d{4})/);
+  if (wfMatch) {
+    const months = { Jan:"01",Feb:"02",Mar:"03",Apr:"04",May:"05",Jun:"06",Jul:"07",Aug:"08",Sep:"09",Oct:"10",Nov:"11",Dec:"12" };
+    return `${wfMatch[3]}-${months[wfMatch[1]]}-${wfMatch[2].padStart(2,"0")}`;
+  }
+  return null;
 }
 
 // History
@@ -363,17 +513,14 @@ async function loadHistory(limit = 7, append = false) {
     return;
   }
 
-  if (!append) {
-    historyList.innerHTML = '<div class="spinner"></div>';
-    historyLoadMore.classList.add("hidden");
-  }
-  btnLoadMore.disabled = true;
+  if (historyObserver) { historyObserver.disconnect(); historyObserver = null; }
+  historyList.innerHTML = '<div class="spinner"></div>';
   try {
     const groups = await apiRequest(
-      `/history?parent_id=${encodeURIComponent(dest.nodeId)}&daily_note=${dest.dailyNoteEnabled}&limit=${limit}`
+      `/history?parent_id=${encodeURIComponent(dest.nodeId)}&daily_note=${dest.dailyNoteEnabled}`
     );
     if (!groups.length) {
-      if (!append) historyList.innerHTML = '<p class="text-muted">No items found</p>';
+      historyList.innerHTML = '<p class="text-muted">No items found</p>';
       return;
     }
 
@@ -464,37 +611,16 @@ async function loadHistory(limit = 7, append = false) {
         })
         .join("");
     }
-    if (append) {
-      const existingNodeIds = new Set(
-        [...historyList.querySelectorAll(".history-item[data-node-id]")].map((el) => el.dataset.nodeId)
-      );
-      const existingDates = new Set(
-        [...historyList.querySelectorAll(".history-date-header .history-date-text")].map((el) => el.textContent)
-      );
-      const temp = document.createElement("div");
-      temp.innerHTML = html;
-      temp.querySelectorAll(".history-item[data-node-id]").forEach((el) => {
-        if (existingNodeIds.has(el.dataset.nodeId)) el.remove();
-      });
-      temp.querySelectorAll(".history-date-header").forEach((el) => {
-        const dateText = el.querySelector(".history-date-text")?.textContent ?? el.textContent;
-        if (existingDates.has(dateText)) el.remove();
-      });
-      historyList.append(...temp.childNodes);
-    } else {
-      historyList.innerHTML = html || '<p class="text-muted">No items found</p>';
-      historyList.addEventListener("click", handleHistoryClick);
-    }
+    historyList.innerHTML = html || '<p class="text-muted">No items found</p>';
+    historyList.addEventListener("click", handleHistoryClick);
 
-    if (groups.length >= limit) {
-      btnLoadMore.dataset.currentLimit = String(limit);
-      historyLoadMore.classList.remove("hidden");
+    const last = groups[groups.length - 1];
+    if (last.hasMore && dest.dailyNoteEnabled) {
+      const nextBeforeDate = parseDateText(last.date || "");
+      if (nextBeforeDate) setupInfiniteScroll(nextBeforeDate);
     }
   } catch (e) {
-    if (!append) historyList.innerHTML = `<p class="text-muted">${escapeHtml(e.message)}</p>`;
-  } finally {
-    btnLoadMore.disabled = false;
-    btnLoadMore.textContent = "Load more";
+    historyList.innerHTML = `<p class="text-muted">${escapeHtml(e.message)}</p>`;
   }
 }
 
@@ -784,11 +910,11 @@ function handleShareTarget() {
       const displayTitle = title || fetchedTitle || url;
       const current = editor.value;
       editor.value = current + `[${displayTitle}](${url})`;
-      editor.focus();
+      openModal(modalCompose, () => editor.focus());
     });
   } else if (text) {
     editor.value = (editor.value || "") + text;
-    editor.focus();
+    openModal(modalCompose, () => editor.focus());
   }
 
   // Clean URL

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -55,7 +55,6 @@ export function sanitizeHtml(html) {
       if (child.nodeType === Node.ELEMENT_NODE && child.tagName === "A") {
         const href = child.getAttribute("href") || "";
         if (/^https?:\/\//i.test(href)) {
-          // Keep only href, add safe attributes
           const safe = document.createElement("a");
           safe.href = href;
           safe.target = "_blank";
@@ -66,7 +65,6 @@ export function sanitizeHtml(html) {
           child.replaceWith(document.createTextNode(child.textContent));
         }
       } else {
-        // Replace non-<a> elements with their text content
         child.replaceWith(document.createTextNode(child.textContent));
       }
     }

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -61,16 +61,14 @@ html, body {
   overflow: hidden;
 }
 
-/* Main editor */
+/* Main history area */
 .main {
   flex: 1;
-  display: flex;
-  padding: 36px 32px;
-  padding-bottom: 0;
+  overflow-y: auto;
+  padding: 16px;
 }
 
 .editor {
-  flex: 1;
   background: transparent;
   border: none;
   outline: none;
@@ -83,6 +81,11 @@ html, body {
 
 .editor::placeholder {
   color: var(--text-dim);
+}
+
+.compose-editor {
+  width: 100%;
+  min-height: 160px;
 }
 
 /* Toolbar */
@@ -635,6 +638,23 @@ html, body {
   font-size: 14px;
   font-weight: 600;
   color: var(--text-muted);
+}
+
+/* Infinite scroll sentinel */
+.history-sentinel {
+  display: flex;
+  justify-content: center;
+  padding: 16px;
+  min-height: 1px;
+}
+
+/* Compose modal */
+#modal-compose .modal-body {
+  gap: 12px;
+}
+
+#modal-compose #btn-send {
+  align-self: flex-end;
 }
 
 /* History */

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import { setCookie, getCookie } from "hono/cookie";
 import { WorkflowyClient } from "./workflowy-v1";
 import { encrypt, decrypt } from "./crypto";
+import { filterDailyNotesByBeforeDate, parseDateFromNodeName } from "./history";
 import type { Env } from "../types";
 
 type AppEnv = { Bindings: Env };
@@ -110,53 +111,29 @@ api.get("/history", async (c) => {
   if (!parentId) return c.json({ error: "parent_id required" }, 400);
 
   const dailyNote = c.req.query("daily_note") === "true";
-  const limit = Math.max(1, parseInt(c.req.query("limit") || "7", 10) || 7);
+  const beforeDate = c.req.query("before_date") || null;
   const client = new WorkflowyClient(apiKey);
 
   if (dailyNote) {
     const dateNodes = await client.getNodes(parentId);
+    const recent = filterDailyNotesByBeforeDate(dateNodes, beforeDate);
 
-    // priorityベースで候補を絞り込み（上位limit*2件）
-    const candidates = dateNodes.sort((a, b) => b.priority - a.priority).slice(0, limit * 2);
-
-    // 日付文字列でソート（降順）してlimit件取得
-    // [YYYY-MM-DD]形式とWorkflowy形式（Mon, Jan 1, 2026）の両方に対応
-    const sorted = candidates
-      .map((node) => {
-        const name = node.name || "";
-        const bracketMatch = name.match(/\[(\d{4}-\d{2}-\d{2})\]/);
-        if (bracketMatch) {
-          return { node, dateStr: bracketMatch[1] };
-        }
-        const workflowyMatch = name.match(/\w{3}, (\w{3}) (\d{1,2}), (\d{4})/);
-        if (workflowyMatch) {
-          const months: Record<string, string> = {
-            Jan: "01", Feb: "02", Mar: "03", Apr: "04", May: "05", Jun: "06",
-            Jul: "07", Aug: "08", Sep: "09", Oct: "10", Nov: "11", Dec: "12",
-          };
-          const month = months[workflowyMatch[1]] || "01";
-          const day = workflowyMatch[2].padStart(2, "0");
-          const year = workflowyMatch[3];
-          return { node, dateStr: `${year}-${month}-${day}` };
-        }
-        return { node, dateStr: null };
-      })
-      .filter((item): item is { node: typeof candidates[0]; dateStr: string } => item.dateStr !== null)
-      .sort((a, b) => b.dateStr.localeCompare(a.dateStr))
-      .map((item) => item.node);
-
-    const results: { date: string; dateId: string; items: typeof dateNodes }[] = [];
-    for (const dateNode of sorted) {
-      if (results.length >= limit) break;
+    const results: { date: string; dateId: string; items: typeof dateNodes; hasMore: boolean }[] = [];
+    for (const dateNode of recent) {
       const children = await client.getNodes(dateNode.id);
       if (children.length === 0) continue;
-      results.push({ date: dateNode.name, dateId: dateNode.id, items: children });
+      results.push({ date: dateNode.name, dateId: dateNode.id, items: children, hasMore: false });
     }
+
+    const oldestDate = recent.length > 0 ? parseDateFromNodeName(recent[recent.length - 1].name || "") : null;
+    const hasMore = oldestDate !== null && filterDailyNotesByBeforeDate(dateNodes, oldestDate).length > 0;
+    if (results.length > 0) results[results.length - 1].hasMore = hasMore;
+
     return c.json(results);
   }
 
   const nodes = await client.getNodes(parentId);
-  return c.json(nodes.map((n) => ({ date: null, items: [n] })));
+  return c.json(nodes.map((n) => ({ date: null, items: [n], hasMore: false })));
 });
 
 // Complete node

--- a/src/api/history.ts
+++ b/src/api/history.ts
@@ -1,0 +1,39 @@
+import type { WorkflowyNode } from "../types";
+
+const MONTHS: Record<string, string> = {
+  Jan: "01", Feb: "02", Mar: "03", Apr: "04", May: "05", Jun: "06",
+  Jul: "07", Aug: "08", Sep: "09", Oct: "10", Nov: "11", Dec: "12",
+};
+
+export function parseDateFromNodeName(name: string): string | null {
+  const bracketMatch = name.match(/\[(\d{4}-\d{2}-\d{2})\]/);
+  if (bracketMatch) return bracketMatch[1];
+
+  const workflowyMatch = name.match(/\w{3}, (\w{3}) (\d{1,2}), (\d{4})/);
+  if (workflowyMatch) {
+    const month = MONTHS[workflowyMatch[1]];
+    if (!month) return null;
+    const day = workflowyMatch[2].padStart(2, "0");
+    const year = workflowyMatch[3];
+    return `${year}-${month}-${day}`;
+  }
+
+  return null;
+}
+
+export function filterDailyNotesByBeforeDate(
+  nodes: WorkflowyNode[],
+  beforeDate: string | null,
+  limit = 7
+): WorkflowyNode[] {
+  const dated = nodes
+    .map((node) => ({ node, dateStr: parseDateFromNodeName(node.name || "") }))
+    .filter((item): item is { node: WorkflowyNode; dateStr: string } => item.dateStr !== null)
+    .sort((a, b) => b.dateStr.localeCompare(a.dateStr));
+
+  const filtered = beforeDate
+    ? dated.filter((item) => item.dateStr < beforeDate)
+    : dated;
+
+  return filtered.slice(0, limit).map((item) => item.node);
+}

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -4,12 +4,9 @@ export const MainPage: FC = () => (
   <div id="app">
     <div id="toast" class="toast hidden"></div>
     <main class="main">
-      <textarea
-        id="editor"
-        class="editor"
-        placeholder="Type your note here...&#10;&#10;(Empty line separates name and note)"
-        autofocus
-      ></textarea>
+      <div id="history-list" class="history-list">
+        <p class="text-muted">Loading...</p>
+      </div>
     </main>
     <footer class="toolbar">
       <div class="toolbar-left">
@@ -24,12 +21,9 @@ export const MainPage: FC = () => (
         <button id="btn-settings" class="btn" title="Settings">
           <iconify-icon icon="heroicons:cog-6-tooth" width="20" height="20"></iconify-icon>
         </button>
-        <button id="btn-history" class="btn" title="History">
-          <iconify-icon icon="heroicons:clock" width="20" height="20"></iconify-icon>
-        </button>
-        <button id="btn-send" class="btn btn-send" title="Send">
-          <iconify-icon icon="heroicons:paper-airplane" width="16" height="16"></iconify-icon>
-          Send
+        <button id="btn-compose" class="btn btn-send" title="New note">
+          <iconify-icon icon="heroicons:pencil-square" width="16" height="16"></iconify-icon>
+          New note
         </button>
       </div>
     </footer>
@@ -126,21 +120,24 @@ export const MainPage: FC = () => (
       </div>
     </div>
 
-    {/* History Modal */}
-    <div id="modal-history" class="modal hidden">
+    {/* Compose Modal */}
+    <div id="modal-compose" class="modal hidden">
       <div class="modal-backdrop"></div>
       <div class="modal-content">
         <div class="modal-header">
-          <h2>History</h2>
-          <button class="modal-close" data-close-modal="modal-history">&times;</button>
+          <h2>New note</h2>
+          <button class="modal-close" data-close-modal="modal-compose">&times;</button>
         </div>
         <div class="modal-body">
-          <div id="history-list" class="history-list">
-            <p class="text-muted">Loading...</p>
-          </div>
-          <div id="history-load-more" class="history-load-more hidden">
-            <button id="btn-load-more" class="btn btn-small">Load more</button>
-          </div>
+          <textarea
+            id="editor"
+            class="editor compose-editor"
+            placeholder="Type your note here...&#10;&#10;(Empty line separates name and note)"
+          ></textarea>
+          <button id="btn-send" class="btn btn-send btn-small">
+            <iconify-icon icon="heroicons:paper-airplane" width="14" height="14"></iconify-icon>
+            Send
+          </button>
         </div>
       </div>
     </div>

--- a/src/test/handlers.test.ts
+++ b/src/test/handlers.test.ts
@@ -91,21 +91,21 @@ describe("GET /api/history", () => {
       expect(data.length).toBeLessThanOrEqual(7);
     });
 
-    it("respects limit query parameter", async () => {
+    it("respects before_date query parameter", async () => {
       const dateNodes = Array.from({ length: 10 }, (_, i) => {
-        const d = String(i + 1).padStart(2, "0");
+        const d = String(10 - i).padStart(2, "0");
         return makeNode({ id: `date-${i}`, name: `[2026-01-${d}]`, priority: i });
       });
       mockGetNodes
         .mockResolvedValueOnce(dateNodes)
         .mockResolvedValue([makeNode()]);
 
-      const req = makeRequest("/api/history?parent_id=parent-1&daily_note=true&limit=3");
+      const req = makeRequest("/api/history?parent_id=parent-1&daily_note=true&before_date=2026-01-05");
       const res = await app.fetch(req, testEnv);
       const data = await res.json() as unknown[];
 
       expect(res.status).toBe(200);
-      expect(data).toHaveLength(3);
+      expect(data).toHaveLength(4); // 2026-01-04, 03, 02, 01
     });
 
     it("excludes date groups with no child nodes", async () => {

--- a/src/test/history.test.ts
+++ b/src/test/history.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { filterDailyNotesByBeforeDate, parseDateFromNodeName } from "../api/history";
+import type { WorkflowyNode } from "../types";
+
+function makeNode(overrides: Partial<WorkflowyNode> = {}): WorkflowyNode {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    note: null,
+    priority: 0,
+    createdAt: 0,
+    modifiedAt: 0,
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+describe("parseDateFromNodeName", () => {
+  it("parses [YYYY-MM-DD] format", () => {
+    expect(parseDateFromNodeName("[2026-05-27]")).toBe("2026-05-27");
+  });
+
+  it("parses Workflowy format (Mon, Jan 1, 2026)", () => {
+    expect(parseDateFromNodeName("Tue, May 27, 2026")).toBe("2026-05-27");
+  });
+
+  it("returns null for unrecognized format", () => {
+    expect(parseDateFromNodeName("some random text")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseDateFromNodeName("")).toBeNull();
+  });
+});
+
+describe("filterDailyNotesByBeforeDate", () => {
+  const nodes = [
+    makeNode({ id: "1", name: "[2026-05-27]", priority: 1 }),
+    makeNode({ id: "2", name: "[2026-05-26]", priority: 2 }),
+    makeNode({ id: "3", name: "[2026-05-25]", priority: 3 }),
+    makeNode({ id: "4", name: "[2026-05-24]", priority: 4 }),
+    makeNode({ id: "5", name: "[2026-05-23]", priority: 5 }),
+    makeNode({ id: "6", name: "[2026-05-22]", priority: 6 }),
+    makeNode({ id: "7", name: "[2026-05-21]", priority: 7 }),
+    makeNode({ id: "8", name: "[2026-05-20]", priority: 8 }),
+    makeNode({ id: "9", name: "not a date node", priority: 9 }),
+  ];
+
+  it("returns latest 7 days when no before_date specified", () => {
+    const result = filterDailyNotesByBeforeDate(nodes, null);
+    expect(result).toHaveLength(7);
+    expect(result[0].id).toBe("1");
+    expect(result[6].id).toBe("7");
+  });
+
+  it("returns up to 7 days strictly older than before_date", () => {
+    const result = filterDailyNotesByBeforeDate(nodes, "2026-05-25");
+    expect(result).toHaveLength(5);
+    expect(result[0].id).toBe("4"); // 2026-05-24
+    expect(result[4].id).toBe("8"); // 2026-05-20
+  });
+
+  it("excludes nodes without parseable dates", () => {
+    const result = filterDailyNotesByBeforeDate(nodes, null);
+    expect(result.every((n) => n.id !== "9")).toBe(true);
+  });
+
+  it("returns fewer than 7 if not enough nodes exist", () => {
+    const few = nodes.slice(0, 3);
+    const result = filterDailyNotesByBeforeDate(few, null);
+    expect(result).toHaveLength(3);
+  });
+
+  it("returns empty array when before_date is older than all nodes", () => {
+    const result = filterDailyNotesByBeforeDate(nodes, "2026-05-01");
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Historyリストをメイン画面のデフォルト表示に変更
- 投稿フォーム（エディタ＋Sendボタン）を「New note」ボタンで開くモーダルに移動
- dailyNoteモードのHistoryにInfinite Scrollを実装（一番下までスクロールで続きを読み込み）

## Changes

- `MainPage.tsx`: `<main>` を `#history-list` 表示エリアに変更。History/Sendボタンを削除し `btn-compose` を追加。`modal-compose`（投稿フォーム）を新規追加
- `client.js`: 起動時・送信後・destination切り替え時にHistoryを自動リロード。Web Share Target受信時も `modal-compose` を開くよう対応。Load moreボタンを廃止し `IntersectionObserver` によるInfinite Scrollに置き換え
- `handlers.ts`: `/history` エンドポイントの `limit` パラメータを `before_date` に変更。レスポンスに `hasMore` フラグを追加
- `src/api/history.ts`（新規）: 日付パース・フィルタリングロジックを純粋関数として切り出し（テスト対象）
- `src/test/history.test.ts`（新規）: 上記関数のユニットテスト9件追加

## Test plan

- [ ] アプリ起動時にHistoryがデフォルト表示される
- [ ] 「New note」ボタンでComposeモーダルが開き、送信後に閉じてHistoryが更新される
- [ ] Destination切り替え時にHistoryが更新される
- [ ] dailyNoteモードで一番下までスクロールすると続きが読み込まれる
- [ ] `npm run test:run` が全件パスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)