### PR TITLE
feat(ui): Redesign layout with FAB compose button and flat history items

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -59,13 +59,14 @@ html, body {
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  position: relative;
 }
 
 /* Main history area */
 .main {
   flex: 1;
   overflow-y: auto;
-  padding: 16px;
+  padding: 0;
 }
 
 .editor {
@@ -657,11 +658,39 @@ html, body {
   align-self: flex-end;
 }
 
+/* Compose FAB */
+.btn-compose-fab {
+  position: absolute;
+  bottom: calc(56px + 16px + env(safe-area-inset-bottom));
+  right: 16px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--nord6);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  transition: background 0.15s, transform 0.15s;
+  z-index: 90;
+}
+
+.btn-compose-fab:hover {
+  background: var(--accent-hover);
+  transform: scale(1.05);
+}
+
+.btn-compose-fab:active {
+  transform: scale(0.95);
+}
+
 /* History */
 .history-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
 }
 
 .history-load-more {
@@ -677,9 +706,13 @@ html, body {
   font-size: 13px;
   font-weight: 600;
   color: var(--text-muted);
-  padding: 4px 0;
-  margin-top: 4px;
+  padding: 8px 8px;
+  background: var(--bg-light);
+  border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .history-date-text {
@@ -727,10 +760,9 @@ html, body {
   display: flex;
   align-items: flex-start;
   gap: 8px;
-  padding: 10px 12px;
-  background: var(--bg);
-  border-radius: var(--radius);
-  font-size: 14px;
+  padding: 12px 8px;
+  border-bottom: 1px solid var(--border);
+  font-size: var(--font-size);
 }
 
 .history-item-toggle {

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -21,12 +21,13 @@ export const MainPage: FC = () => (
         <button id="btn-settings" class="btn" title="Settings">
           <iconify-icon icon="heroicons:cog-6-tooth" width="20" height="20"></iconify-icon>
         </button>
-        <button id="btn-compose" class="btn btn-send" title="New note">
-          <iconify-icon icon="heroicons:pencil-square" width="16" height="16"></iconify-icon>
-          New note
-        </button>
       </div>
     </footer>
+
+    {/* Compose FAB */}
+    <button id="btn-compose" class="btn-compose-fab" title="New note">
+      <iconify-icon icon="heroicons:pencil-square" width="24" height="24"></iconify-icon>
+    </button>
 
     {/* Settings Modal */}
     <div id="modal-settings" class="modal hidden">


### PR DESCRIPTION
## Summary
- Composeボタンをツールバーから右下のFAB（フローティングアクションボタン）に移動
- historyアイテムをカードスタイルからディバイダー線区切りのフラットスタイルに変更
- 日付ヘッダーをstickyにして、スクロール時に上部に固定表示
- mainエリアのpaddingを撤廃し、各アイテムで個別に管理

## Changes
- `public/styles/main.css`: FABスタイル追加、historyアイテムのカード→フラット化、日付ヘッダーsticky化
- `src/components/pages/MainPage.tsx`: ComposeボタンをFABとして`#app`直下に配置

## Test Plan
- [ ] Composeボタン（FAB）をクリックしてモーダルが開くことを確認
- [ ] デスクトップ表示でFABが`#app`内の右下に収まることを確認（画面右端にはみ出さない）
- [ ] historyアイテムがディバイダー線で区切られて表示されることを確認
- [ ] スクロール時に日付ヘッダーが上部に固定されることを確認