### PR TITLE
feat(daily-note): Workflowyネイティブカレンダーに全面移行

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@ npm run test:ui    # vitest UI起動
 ## Key Concepts
 
 - **認証**: APIキーはHTTP-only Cookieに暗号化して保存
-- **Daily Note**: Workflowyカレンダーと互換のある日付ノード形式 `[YYYY-MM-DD]`
+- **Daily Note**: Workflowyネイティブカレンダーを使用。送信は `parent_id="today"`（Day NodeはWF側でオンデマンド作成）、履歴は日付キー `YYYY-MM-DD` を1日ずつ遡ってプローブ（404 = その日ノート無し）
+- **Destination**: `type: "node" | "calendar"`。旧 `dailyNoteEnabled` は `migrateSettings` がLocalStorage読み込み時に自動変換
 - **Template**: `{content}`, `{YYYY}`, `{MM}`, `{DD}`, `{HH}`, `{mm}`, `{ss}` プレースホルダー対応
 - **URL展開**: 送信時にプレーンURLをMarkdownリンクに自動変換
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A modern, streamlined note-taking app for Workflowy using the official API. Quic
 
 - **Official Workflowy API Integration** - Uses the stable, official API
 - **Multiple Destinations** - Configure multiple save locations with custom names
-- **Daily Note Support** - Automatically organize notes under daily date headers
+- **Daily Note Support** - Send notes straight into Workflowy's native calendar (today's Day Node)
 - **Template System** - Customize note format with date/time placeholders
 - **Smart URL Expansion** - Automatically converts URLs to Markdown links with page titles on send
 - **PWA Support** - Install as a standalone app, works offline, supports Web Share Target
@@ -45,9 +45,11 @@ npm run deploy
 
 ### 4. Set Up Destinations
 1. In Settings, click "+ Add destination"
-2. Navigate to your desired Workflowy location
+2. Choose the destination type:
+   - **Node** - Navigate to your desired Workflowy location
+   - **Calendar (Daily Note)** - Notes go to today's node in Workflowy's native calendar
 3. Enter a display name
-4. Optionally enable Daily Note and customize the template
+4. Optionally customize the template
 5. Click Save
 
 ## Usage
@@ -83,12 +85,15 @@ When you send a note containing URLs, Jotflowy automatically:
 
 ### Daily Note
 
-When Daily Note is enabled for a destination:
+With a Calendar (Daily Note) destination:
 
-- Notes are automatically organized under a daily header (YYYY-MM-DD format)
-- Multiple notes on the same day go under the same header
-- Compatible with [Workflowy Calendar](https://workflowy.com/learn/calendar/) - daily notes appear in your calendar view
+- Notes are sent to today's Day Node in [Workflowy's native calendar](https://workflowy.com/help/calendar/) - the same node Workflowy opens for "Today"
+- Day Nodes are created on demand by Workflowy, so no duplicate date nodes are ever created
+- History shows your recent days with links to each Day Node
 - Great for journaling, daily logs, or time-based organization
+
+> [!NOTE]
+> Older versions of Jotflowy created plain-text `[YYYY-MM-DD]` nodes under a destination of your choice. Those nodes are no longer shown in history. To merge them into the native calendar, use Workflowy's [calendar migration tools](https://workflowy.com/help/calendar/).
 
 ## Development
 

--- a/public/scripts/client.js
+++ b/public/scripts/client.js
@@ -1,4 +1,4 @@
-import { applyTemplate, parseContent, escapeRegex, escapeHtml, stripHtml, sanitizeHtml, applyTypographySettings, FONT_FAMILY_MAP } from "./utils.js";
+import { applyTemplate, parseContent, escapeRegex, escapeHtml, stripHtml, sanitizeHtml, applyTypographySettings, FONT_FAMILY_MAP, migrateSettings } from "./utils.js";
 
 // State
 let settings = loadSettings();
@@ -32,7 +32,7 @@ const btnAddDestination = document.getElementById("btn-add-destination");
 const panelAddDest = document.getElementById("panel-add-destination");
 const nodeTree = document.getElementById("node-tree");
 const destNameInput = document.getElementById("dest-name-input");
-const destDailyNote = document.getElementById("dest-daily-note");
+const destTypeRadios = document.querySelectorAll('input[name="dest-type"]');
 const destDefaultText = document.getElementById("dest-default-text");
 const btnSaveDestination = document.getElementById("btn-save-destination");
 const btnCancelDestination = document.getElementById("btn-cancel-destination");
@@ -160,9 +160,13 @@ function bindEvents() {
     selectedNodeId = null;
     nodeTreePath = [];
     destNameInput.value = "";
-    destDailyNote.checked = false;
+    setDestType("node");
     destDefaultText.value = "";
     loadNodeTree();
+  });
+
+  destTypeRadios.forEach((radio) => {
+    radio.addEventListener("change", () => updateDestTypeUI(getDestType()));
   });
 
   btnSaveDestination.addEventListener("click", saveDestination);
@@ -203,7 +207,7 @@ function toggleDestinationDropdown() {
     const isActive = dest.id === settings.selectedDestinationId;
     const item = document.createElement("div");
     item.className = "destination-dropdown-item" + (isActive ? " active" : "");
-    item.textContent = dest.name;
+    item.innerHTML = destinationNameHtml(dest);
     item.addEventListener("click", (e) => {
       e.stopPropagation();
       settings.selectedDestinationId = dest.id;
@@ -221,7 +225,16 @@ function toggleDestinationDropdown() {
 function loadSettings() {
   try {
     const raw = localStorage.getItem("jotflowy_settings");
-    if (raw) return JSON.parse(raw);
+    if (raw) {
+      const { settings: migrated, changed } = migrateSettings(JSON.parse(raw));
+      if (changed) {
+        localStorage.setItem("jotflowy_settings", JSON.stringify(migrated));
+        // Old caches hold "[YYYY-MM-DD]" group keys, incompatible with the
+        // ISO date keys used after migration
+        localStorage.removeItem("jotflowy_history_cache");
+      }
+      return migrated;
+    }
   } catch {}
   return { destinations: [], selectedDestinationId: "", fontSize: 16, lineHeight: 1.8, fontFamily: "gothic" };
 }
@@ -265,9 +278,21 @@ function getSelectedDestination() {
   return settings.destinations.find((d) => d.id === settings.selectedDestinationId) || null;
 }
 
+// Marks calendar destinations as a kind, not a node name
+const calendarTypeIcon = `<svg class="dest-type-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="4" width="18" height="18" rx="2" />
+  <line x1="16" y1="2" x2="16" y2="6" />
+  <line x1="8" y1="2" x2="8" y2="6" />
+  <line x1="3" y1="10" x2="21" y2="10" />
+</svg>`;
+
+function destinationNameHtml(dest) {
+  return `${dest.type === "calendar" ? calendarTypeIcon : ""}${escapeHtml(dest.name)}`;
+}
+
 function updateDestinationLabel() {
   const dest = getSelectedDestination();
-  destinationLabel.textContent = dest ? dest.name : "No destination";
+  destinationLabel.innerHTML = dest ? destinationNameHtml(dest) : "No destination";
 }
 
 
@@ -342,6 +367,20 @@ async function expandUrls(text) {
 }
 
 
+function todayLocalDate() {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+function historyQuery(dest, beforeDate) {
+  if (dest.type === "calendar") {
+    return beforeDate
+      ? `/history?calendar=true&before_date=${encodeURIComponent(beforeDate)}`
+      : `/history?calendar=true&local_date=${todayLocalDate()}`;
+  }
+  return `/history?parent_id=${encodeURIComponent(dest.nodeId)}`;
+}
+
 // Send
 async function handleSend() {
   const text = editor.value.trim();
@@ -359,17 +398,17 @@ async function handleSend() {
     const { name, note } = parseContent(expandedText);
     const finalName = dest.defaultText ? applyTemplate(dest.defaultText, name) : name;
 
-    const now = new Date();
-    const localDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    // The server sends calendar notes to Workflowy's "today"; localDate is
+    // only used client-side for optimistic history grouping
+    const localDate = todayLocalDate();
 
     const result = await apiRequest("/send", {
       method: "POST",
       body: JSON.stringify({
-        destinationId: dest.nodeId,
+        targetType: dest.type,
+        parentId: dest.type === "node" ? dest.nodeId : undefined,
         name: finalName,
         note,
-        dailyNoteEnabled: dest.dailyNoteEnabled,
-        localDate: dest.dailyNoteEnabled ? localDate : undefined,
       }),
     });
 
@@ -399,17 +438,14 @@ function optimisticInsert(dest, name, note, localDate, itemId) {
 
   let groups = getHistoryCache(dest.id) || [];
 
-  if (dest.dailyNoteEnabled) {
-    const todayIndex = groups.findIndex((g) => {
-      if (!g.date) return false;
-      return parseDateText(g.date) === localDate;
-    });
+  if (dest.type === "calendar") {
+    const todayIndex = groups.findIndex((g) => g.date === localDate);
 
     if (todayIndex >= 0) {
       groups[todayIndex].items.push(tempNode);
     } else {
       groups.unshift({
-        date: `[${localDate}]`,
+        date: localDate,
         dateId: null,
         items: [tempNode],
         hasMore: false,
@@ -441,9 +477,7 @@ function optimisticInsert(dest, name, note, localDate, itemId) {
 
 async function refreshHistoryInBackground(dest) {
   try {
-    const groups = await apiRequest(
-      `/history?parent_id=${encodeURIComponent(dest.nodeId)}&daily_note=${dest.dailyNoteEnabled}`
-    );
+    const groups = await apiRequest(historyQuery(dest));
     setHistoryCache(dest.id, groups);
     if (getSelectedDestination()?.id === dest.id) {
       renderHistoryFromGroups(groups, dest);
@@ -476,7 +510,7 @@ function renderHistoryGroupsHtml(groups) {
   for (const group of groups) {
     if (group.date) {
       const dateWfUrl = group.dateId ? `https://workflowy.com/#/${group.dateId}` : null;
-      const dateText = escapeHtml(parseDateText(stripHtml(group.date)) || stripHtml(group.date));
+      const dateText = escapeHtml(group.date);
       const dateDeleteBtn = group.dateId
         ? `<button class="history-date-delete" data-node-id="${group.dateId}" title="Delete date group">${trashIcon}</button>`
         : "";
@@ -574,9 +608,8 @@ function renderHistoryFromGroups(groups, dest) {
 
   if (historyObserver) { historyObserver.disconnect(); historyObserver = null; }
   const last = groups[groups.length - 1];
-  if (last.hasMore && dest.dailyNoteEnabled) {
-    const nextBeforeDate = parseDateText(last.date || "");
-    if (nextBeforeDate) setupInfiniteScroll(nextBeforeDate);
+  if (last.hasMore && dest.type === "calendar" && last.date) {
+    setupInfiniteScroll(last.date);
   }
 }
 
@@ -618,13 +651,11 @@ function setupInfiniteScroll(beforeDate) {
 
 async function loadMoreHistory(beforeDate) {
   const dest = getSelectedDestination();
-  if (!dest || !dest.dailyNoteEnabled) return;
+  if (!dest || dest.type !== "calendar") return;
 
   const sentinel = historyList.querySelector(".history-sentinel");
   try {
-    const groups = await apiRequest(
-      `/history?parent_id=${encodeURIComponent(dest.nodeId)}&daily_note=true&before_date=${encodeURIComponent(beforeDate)}`
-    );
+    const groups = await apiRequest(historyQuery(dest, beforeDate));
     if (sentinel) sentinel.remove();
     if (historyObserver) { historyObserver.disconnect(); historyObserver = null; }
 
@@ -636,24 +667,12 @@ async function loadMoreHistory(beforeDate) {
     historyList.append(...container.childNodes);
 
     const last = groups[groups.length - 1];
-    if (last.hasMore) {
-      const nextBeforeDate = parseDateText(last.date || "");
-      if (nextBeforeDate) setupInfiniteScroll(nextBeforeDate);
+    if (last.hasMore && last.date) {
+      setupInfiniteScroll(last.date);
     }
   } catch (e) {
     if (sentinel) sentinel.innerHTML = `<p class="text-muted">${escapeHtml(e.message)}</p>`;
   }
-}
-
-function parseDateText(text) {
-  const bracketMatch = text.match(/\[(\d{4}-\d{2}-\d{2})\]/);
-  if (bracketMatch) return bracketMatch[1];
-  const wfMatch = text.match(/\w{3}, (\w{3}) (\d{1,2}), (\d{4})/);
-  if (wfMatch) {
-    const months = { Jan:"01",Feb:"02",Mar:"03",Apr:"04",May:"05",Jun:"06",Jul:"07",Aug:"08",Sep:"09",Oct:"10",Nov:"11",Dec:"12" };
-    return `${wfMatch[3]}-${months[wfMatch[1]]}-${wfMatch[2].padStart(2,"0")}`;
-  }
-  return null;
 }
 
 // History
@@ -671,9 +690,7 @@ async function loadHistory() {
     renderHistoryFromGroups(cached, dest);
     showRefreshIndicator();
     try {
-      const groups = await apiRequest(
-        `/history?parent_id=${encodeURIComponent(dest.nodeId)}&daily_note=${dest.dailyNoteEnabled}`
-      );
+      const groups = await apiRequest(historyQuery(dest));
       setHistoryCache(dest.id, groups);
       if (getSelectedDestination()?.id === dest.id) {
         renderHistoryFromGroups(groups, dest);
@@ -686,9 +703,7 @@ async function loadHistory() {
   } else {
     historyList.innerHTML = '<div class="spinner"></div>';
     try {
-      const groups = await apiRequest(
-        `/history?parent_id=${encodeURIComponent(dest.nodeId)}&daily_note=${dest.dailyNoteEnabled}`
-      );
+      const groups = await apiRequest(historyQuery(dest));
       setHistoryCache(dest.id, groups);
       renderHistoryFromGroups(groups, dest);
     } catch (e) {
@@ -938,6 +953,25 @@ function renderNodeTree(nodes) {
 }
 
 // Destination management
+function getDestType() {
+  return document.querySelector('input[name="dest-type"]:checked')?.value || "node";
+}
+
+function setDestType(type) {
+  destTypeRadios.forEach((radio) => {
+    radio.checked = radio.value === type;
+  });
+  updateDestTypeUI(type);
+}
+
+function updateDestTypeUI(type) {
+  // Calendar destinations write to Workflowy's native calendar; there is no
+  // node to pick and the name is fixed to "Daily Note"
+  const isCalendar = type === "calendar";
+  nodeTree.classList.toggle("hidden", isCalendar);
+  destNameInput.closest(".input-group").classList.toggle("hidden", isCalendar);
+}
+
 function renderDestinationList() {
   destinationList.innerHTML = "";
   if (!settings.destinations.length) {
@@ -949,8 +983,7 @@ function renderDestinationList() {
     const div = document.createElement("div");
     div.className = "destination-item" + (isActive ? " active" : "");
     div.innerHTML = `
-      <span class="destination-item-name">${escapeHtml(dest.name)}</span>
-      ${dest.dailyNoteEnabled ? '<span class="destination-item-badge">Daily</span>' : ""}
+      <span class="destination-item-name">${destinationNameHtml(dest)}</span>
       <button class="destination-item-delete" data-id="${dest.id}">&times;</button>
     `;
     div.addEventListener("click", (e) => {
@@ -977,11 +1010,12 @@ function renderDestinationList() {
 }
 
 function saveDestination() {
-  if (!selectedNodeId) {
+  const type = getDestType();
+  if (type === "node" && !selectedNodeId) {
     showToast("Select a node first", true);
     return;
   }
-  const name = destNameInput.value.trim();
+  const name = type === "calendar" ? "Daily Note" : destNameInput.value.trim();
   if (!name) {
     showToast("Enter a name", true);
     return;
@@ -989,9 +1023,9 @@ function saveDestination() {
 
   const dest = {
     id: crypto.randomUUID(),
-    nodeId: selectedNodeId,
+    type,
+    nodeId: type === "node" ? selectedNodeId : undefined,
     name,
-    dailyNoteEnabled: destDailyNote.checked,
     defaultText: destDefaultText.value,
   };
   settings.destinations.push(dest);

--- a/public/scripts/utils.d.ts
+++ b/public/scripts/utils.d.ts
@@ -5,4 +5,5 @@ export function escapeHtml(str: string): string;
 export function stripHtml(html: string): string;
 export function sanitizeHtml(html: string): string;
 export const FONT_FAMILY_MAP: Record<string, string>;
+export function migrateSettings<T extends { destinations?: unknown[] }>(settings: T): { settings: T; changed: boolean };
 export function applyTypographySettings(settings: { fontSize?: number; lineHeight?: number; fontFamily?: string }): void;

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -16,6 +16,22 @@ export function applyTemplate(template, content, date = new Date()) {
   return result;
 }
 
+// Migrate legacy destinations (dailyNoteEnabled flag) to the type field.
+// Calendar destinations write to Workflowy's native calendar, so the old
+// parent nodeId is dropped. Returns { settings, changed }; when changed,
+// the caller must persist the settings and drop the old history cache.
+export function migrateSettings(settings) {
+  let changed = false;
+  for (const dest of settings.destinations || []) {
+    if (dest.type) continue;
+    dest.type = dest.dailyNoteEnabled ? "calendar" : "node";
+    delete dest.dailyNoteEnabled;
+    if (dest.type === "calendar") delete dest.nodeId;
+    changed = true;
+  }
+  return { settings, changed };
+}
+
 // Parse editor content: split name and note by empty line
 export function parseContent(text) {
   const parts = text.split(/\n\s*\n/);

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -157,6 +157,19 @@ html, body {
   text-overflow: ellipsis;
 }
 
+/* Calendar (Daily Note) destination type marker */
+.dest-type-icon {
+  flex-shrink: 0;
+  opacity: 0.7;
+  vertical-align: -1px;
+}
+
+/* In inline text contexts; flex containers space it via gap */
+#destination-label .dest-type-icon,
+.destination-item-name .dest-type-icon {
+  margin-right: 6px;
+}
+
 .destination-chevron {
   flex-shrink: 0;
   opacity: 0.5;
@@ -533,15 +546,6 @@ html, body {
 .destination-item-name {
   flex: 1;
   font-size: 14px;
-}
-
-.destination-item-badge {
-  font-size: 11px;
-  color: var(--bg);
-  background: var(--success);
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-  font-weight: 600;
 }
 
 .destination-item-delete {

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -3,8 +3,8 @@ import { cors } from "hono/cors";
 import { setCookie, getCookie } from "hono/cookie";
 import { WorkflowyClient } from "./workflowy-v1";
 import { encrypt, decrypt } from "./crypto";
-import { filterDailyNotesByBeforeDate, parseDateFromNodeName } from "./history";
-import type { Env } from "../types";
+import { addDays, dateKeysBack } from "./history";
+import type { Env, HistoryGroup, WorkflowyNode } from "../types";
 
 type AppEnv = { Bindings: Env };
 
@@ -88,52 +88,87 @@ api.post("/nodes", async (c) => {
 api.post("/send", async (c) => {
   const apiKey = await getApiKey(c as never);
   const body = await c.req.json<{
-    destinationId: string;
+    targetType: "node" | "calendar";
+    parentId?: string;
     name: string;
     note?: string;
-    dailyNoteEnabled: boolean;
-    localDate?: string;
   }>();
-  const client = new WorkflowyClient(apiKey);
 
-  let parentId = body.destinationId;
-  if (body.dailyNoteEnabled) {
-    parentId = await client.getOrCreateDailyNote(parentId, body.localDate);
+  // Workflowy creates the calendar day node on demand; "today" resolves
+  // server-side, so no date handling is needed here.
+  let parentId: string;
+  if (body.targetType === "calendar") {
+    parentId = "today";
+  } else if (body.targetType === "node") {
+    if (!body.parentId) return c.json({ error: "parentId required" }, 400);
+    parentId = body.parentId;
+  } else {
+    return c.json({ error: "invalid targetType" }, 400);
   }
 
+  const client = new WorkflowyClient(apiKey);
   const result = await client.createNode(parentId, body.name, body.note);
   return c.json(result);
 });
 
+const HISTORY_GROUP_LIMIT = 7;
+// Cap per request; keep probes + dateId lookups well under the
+// Cloudflare Workers subrequest limit (50).
+const MAX_SCAN_DAYS = 31;
+const PROBE_BATCH_SIZE = 7;
+
 api.get("/history", async (c) => {
   const apiKey = await getApiKey(c as never);
-  const parentId = c.req.query("parent_id");
-  if (!parentId) return c.json({ error: "parent_id required" }, 400);
-
-  const dailyNote = c.req.query("daily_note") === "true";
-  const beforeDate = c.req.query("before_date") || null;
   const client = new WorkflowyClient(apiKey);
 
-  if (dailyNote) {
-    const dateNodes = await client.getNodes(parentId);
-    const recent = filterDailyNotesByBeforeDate(dateNodes, beforeDate);
+  if (c.req.query("calendar") === "true") {
+    const beforeDate = c.req.query("before_date");
+    const localDate = c.req.query("local_date");
+    // Scan backward from before_date - 1 when paginating; on initial load
+    // start at local_date + 1 to cover client/Workflowy timezone skew.
+    const anchor = beforeDate || localDate;
+    if (!anchor || !/^\d{4}-\d{2}-\d{2}$/.test(anchor)) {
+      return c.json({ error: "local_date or before_date (YYYY-MM-DD) required" }, 400);
+    }
+    const start = beforeDate ? addDays(beforeDate, -1) : addDays(anchor, 1);
 
-    const results: { date: string; dateId: string; items: typeof dateNodes; hasMore: boolean }[] = [];
-    for (const dateNode of recent) {
-      const children = await client.getNodes(dateNode.id);
-      if (children.length === 0) continue;
-      results.push({ date: dateNode.name, dateId: dateNode.id, items: children, hasMore: false });
+    const collected: { date: string; items: WorkflowyNode[] }[] = [];
+    let scanned = 0;
+    while (scanned < MAX_SCAN_DAYS && collected.length < HISTORY_GROUP_LIMIT) {
+      const batchKeys = dateKeysBack(
+        addDays(start, -scanned),
+        Math.min(PROBE_BATCH_SIZE, MAX_SCAN_DAYS - scanned)
+      );
+      const children = await Promise.all(batchKeys.map((key) => client.getCalendarNodes(key)));
+      batchKeys.forEach((key, i) => {
+        if (children[i].length > 0) collected.push({ date: key, items: children[i] });
+      });
+      scanned += batchKeys.length;
     }
 
-    const oldestDate = recent.length > 0 ? parseDateFromNodeName(recent[recent.length - 1].name || "") : null;
-    const hasMore = oldestDate !== null && filterDailyNotesByBeforeDate(dateNodes, oldestDate).length > 0;
+    // Filled the page => likely more below; scan cap reached => end of scroll.
+    const hasMore = collected.length >= HISTORY_GROUP_LIMIT;
+    const recent = collected.slice(0, HISTORY_GROUP_LIMIT);
+
+    const dayNodes = await Promise.all(
+      recent.map((group) => client.getNode(group.date).catch(() => null))
+    );
+    const results: HistoryGroup[] = recent.map((group, i) => ({
+      date: group.date,
+      dateId: dayNodes[i]?.id ?? null,
+      items: group.items,
+      hasMore: false,
+    }));
     if (results.length > 0) results[results.length - 1].hasMore = hasMore;
 
     return c.json(results);
   }
 
+  const parentId = c.req.query("parent_id");
+  if (!parentId) return c.json({ error: "parent_id required" }, 400);
+
   const nodes = await client.getNodes(parentId);
-  return c.json(nodes.map((n) => ({ date: null, items: [n], hasMore: false })));
+  return c.json(nodes.map((n) => ({ date: null, dateId: null, items: [n], hasMore: false })));
 });
 
 // Complete node

--- a/src/api/history.ts
+++ b/src/api/history.ts
@@ -1,39 +1,19 @@
-import type { WorkflowyNode } from "../types";
+// Date-key helpers for probing Workflowy native calendar nodes.
+// All arithmetic is done in UTC so results are timezone-independent.
 
-const MONTHS: Record<string, string> = {
-  Jan: "01", Feb: "02", Mar: "03", Apr: "04", May: "05", Jun: "06",
-  Jul: "07", Aug: "08", Sep: "09", Oct: "10", Nov: "11", Dec: "12",
-};
-
-export function parseDateFromNodeName(name: string): string | null {
-  const bracketMatch = name.match(/\[(\d{4}-\d{2}-\d{2})\]/);
-  if (bracketMatch) return bracketMatch[1];
-
-  const workflowyMatch = name.match(/\w{3}, (\w{3}) (\d{1,2}), (\d{4})/);
-  if (workflowyMatch) {
-    const month = MONTHS[workflowyMatch[1]];
-    if (!month) return null;
-    const day = workflowyMatch[2].padStart(2, "0");
-    const year = workflowyMatch[3];
-    return `${year}-${month}-${day}`;
-  }
-
-  return null;
+export function addDays(iso: string, n: number): string {
+  const date = new Date(`${iso}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + n);
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
-export function filterDailyNotesByBeforeDate(
-  nodes: WorkflowyNode[],
-  beforeDate: string | null,
-  limit = 7
-): WorkflowyNode[] {
-  const dated = nodes
-    .map((node) => ({ node, dateStr: parseDateFromNodeName(node.name || "") }))
-    .filter((item): item is { node: WorkflowyNode; dateStr: string } => item.dateStr !== null)
-    .sort((a, b) => b.dateStr.localeCompare(a.dateStr));
-
-  const filtered = beforeDate
-    ? dated.filter((item) => item.dateStr < beforeDate)
-    : dated;
-
-  return filtered.slice(0, limit).map((item) => item.node);
+export function dateKeysBack(start: string, count: number): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < count; i++) {
+    keys.push(addDays(start, -i));
+  }
+  return keys;
 }

--- a/src/api/workflowy-v1.ts
+++ b/src/api/workflowy-v1.ts
@@ -1,4 +1,4 @@
-import type { WorkflowyNode, WorkflowyNodesResponse, CreateNodeResponse } from "../types";
+import type { WorkflowyNode, WorkflowyNodesResponse, WorkflowyNodeResponse, CreateNodeResponse } from "../types";
 
 const BASE_URL = "https://beta.workflowy.com/api/v1";
 
@@ -9,8 +9,8 @@ export class WorkflowyClient {
     this.apiKey = apiKey;
   }
 
-  private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
-    const res = await fetch(`${BASE_URL}${path}`, {
+  private fetchApi(path: string, options: RequestInit = {}): Promise<Response> {
+    return fetch(`${BASE_URL}${path}`, {
       ...options,
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
@@ -18,6 +18,21 @@ export class WorkflowyClient {
         ...options.headers,
       },
     });
+  }
+
+  private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const res = await this.fetchApi(path, options);
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Workflowy API error ${res.status}: ${text}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  // 404 means the calendar node has not been created yet
+  private async request404AsNull<T>(path: string): Promise<T | null> {
+    const res = await this.fetchApi(path);
+    if (res.status === 404) return null;
     if (!res.ok) {
       const text = await res.text();
       throw new Error(`Workflowy API error ${res.status}: ${text}`);
@@ -44,32 +59,22 @@ export class WorkflowyClient {
     });
   }
 
-  async findDailyNote(parentId: string, dateStr: string): Promise<WorkflowyNode | null> {
-    const nodes = await this.getNodes(parentId);
-    const date = new Date(dateStr + "T00:00:00");
-    const weekday = date.toLocaleDateString("en-US", { weekday: "short" });
-    const month = date.toLocaleDateString("en-US", { month: "short" });
-    const day = date.getDate();
-    const year = date.getFullYear();
-    const workflowyDateText = `${weekday}, ${month} ${day}, ${year}`;
-
-    for (const node of nodes) {
-      const text = node.name || "";
-      if (text.includes(workflowyDateText) || text.includes(dateStr)) {
-        return node;
-      }
-    }
-    return null;
+  // Children of a native calendar node (date key such as "2026-07-13").
+  // 404 = the calendar node doesn't exist yet, i.e. no notes for that day.
+  async getCalendarNodes(dateKey: string): Promise<WorkflowyNode[]> {
+    const data = await this.request404AsNull<WorkflowyNodesResponse>(
+      `/nodes?parent_id=${encodeURIComponent(dateKey)}`
+    );
+    if (!data) return [];
+    return data.nodes.sort((a, b) => a.priority - b.priority);
   }
 
-  async getOrCreateDailyNote(parentId: string, dateStr?: string): Promise<string> {
-    const targetDate = dateStr || formatDate(new Date());
-    const existing = await this.findDailyNote(parentId, targetDate);
-    if (existing) return existing.id;
-
-    const formattedDate = `[${targetDate}]`;
-    const result = await this.createNode(parentId, formattedDate, undefined, "bottom");
-    return result.item_id;
+  // Single node lookup. Accepts node IDs and calendar keys ("today", "YYYY-MM-DD").
+  async getNode(idOrKey: string): Promise<WorkflowyNode | null> {
+    const data = await this.request404AsNull<WorkflowyNodeResponse>(
+      `/nodes/${encodeURIComponent(idOrKey)}`
+    );
+    return data?.node ?? null;
   }
 
   async completeNode(nodeId: string): Promise<void> {
@@ -89,11 +94,4 @@ export class WorkflowyClient {
       method: "DELETE",
     });
   }
-}
-
-function formatDate(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
 }

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -93,17 +93,21 @@ export const MainPage: FC = () => (
               {/* Add destination sub-panel */}
               <div id="panel-add-destination" class="sub-panel hidden">
                 <h3>Add Destination</h3>
+                <div class="checkbox-group" id="dest-type-group">
+                  <label>
+                    <input type="radio" name="dest-type" value="node" checked />
+                    Node
+                  </label>
+                  <label>
+                    <input type="radio" name="dest-type" value="calendar" />
+                    Calendar (Daily Note)
+                  </label>
+                </div>
                 <div id="node-tree" class="node-tree">
                   <p class="text-muted">Loading nodes...</p>
                 </div>
                 <div class="input-group">
                   <input id="dest-name-input" type="text" placeholder="Display name" class="input" />
-                </div>
-                <div class="checkbox-group">
-                  <label>
-                    <input id="dest-daily-note" type="checkbox" />
-                    Enable Daily Note
-                  </label>
                 </div>
                 <div class="input-group">
                   <label class="input-label">Template</label>

--- a/src/test/handlers.test.ts
+++ b/src/test/handlers.test.ts
@@ -3,6 +3,9 @@ import app from "../../src/index";
 import type { WorkflowyNode } from "../types";
 
 const mockGetNodes = vi.fn();
+const mockCreateNode = vi.fn();
+const mockGetCalendarNodes = vi.fn();
+const mockGetNode = vi.fn();
 const mockCompleteNode = vi.fn();
 const mockUncompleteNode = vi.fn();
 const mockDeleteNode = vi.fn();
@@ -10,12 +13,12 @@ const mockDeleteNode = vi.fn();
 vi.mock("../api/workflowy-v1", () => ({
   WorkflowyClient: vi.fn().mockImplementation(() => ({
     getNodes: mockGetNodes,
-    createNode: vi.fn(),
+    createNode: mockCreateNode,
+    getCalendarNodes: mockGetCalendarNodes,
+    getNode: mockGetNode,
     completeNode: mockCompleteNode,
     uncompleteNode: mockUncompleteNode,
     deleteNode: mockDeleteNode,
-    getOrCreateDailyNote: vi.fn(),
-    findDailyNote: vi.fn(),
   })),
 }));
 
@@ -53,17 +56,75 @@ const testEnv = {
   ALLOWED_ORIGINS: "http://localhost",
 };
 
+describe("POST /api/send", () => {
+  beforeEach(() => {
+    mockCreateNode.mockReset();
+    mockGetCalendarNodes.mockReset();
+    mockGetNodes.mockReset();
+    mockCreateNode.mockResolvedValue({ item_id: "created-id" });
+  });
+
+  it("creates node under 'today' for calendar target", async () => {
+    const req = makeRequest("/api/send", {
+      method: "POST",
+      body: JSON.stringify({ targetType: "calendar", name: "Hello", note: "world" }),
+    });
+    const res = await app.fetch(req, testEnv);
+    const data = await res.json() as { item_id: string };
+
+    expect(res.status).toBe(200);
+    expect(data.item_id).toBe("created-id");
+    expect(mockCreateNode).toHaveBeenCalledTimes(1);
+    expect(mockCreateNode).toHaveBeenCalledWith("today", "Hello", "world");
+    expect(mockGetNodes).not.toHaveBeenCalled();
+    expect(mockGetCalendarNodes).not.toHaveBeenCalled();
+  });
+
+  it("creates node under parentId for node target", async () => {
+    const req = makeRequest("/api/send", {
+      method: "POST",
+      body: JSON.stringify({ targetType: "node", parentId: "parent-1", name: "Hello" }),
+    });
+    const res = await app.fetch(req, testEnv);
+
+    expect(res.status).toBe(200);
+    expect(mockCreateNode).toHaveBeenCalledWith("parent-1", "Hello", undefined);
+  });
+
+  it("returns 400 when parentId is missing for node target", async () => {
+    const req = makeRequest("/api/send", {
+      method: "POST",
+      body: JSON.stringify({ targetType: "node", name: "Hello" }),
+    });
+    const res = await app.fetch(req, testEnv);
+    expect(res.status).toBe(400);
+    expect(mockCreateNode).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for unknown targetType", async () => {
+    const req = makeRequest("/api/send", {
+      method: "POST",
+      body: JSON.stringify({ targetType: "inbox", name: "Hello" }),
+    });
+    const res = await app.fetch(req, testEnv);
+    expect(res.status).toBe(400);
+    expect(mockCreateNode).not.toHaveBeenCalled();
+  });
+});
+
 describe("GET /api/history", () => {
   beforeEach(() => {
     mockGetNodes.mockReset();
+    mockGetCalendarNodes.mockReset();
+    mockGetNode.mockReset();
   });
 
-  describe("daily_note=false", () => {
+  describe("node destination", () => {
     it("returns nodes as flat list", async () => {
       const nodes = [makeNode({ id: "n1" }), makeNode({ id: "n2" })];
       mockGetNodes.mockResolvedValue(nodes);
 
-      const req = makeRequest("/api/history?parent_id=parent-1&daily_note=false");
+      const req = makeRequest("/api/history?parent_id=parent-1");
       const res = await app.fetch(req, testEnv);
       const data = await res.json() as Array<{ items: WorkflowyNode[] }>;
 
@@ -71,67 +132,147 @@ describe("GET /api/history", () => {
       expect(data).toHaveLength(2);
       expect(data[0].items[0].id).toBe("n1");
     });
+
+    it("returns 400 when parent_id is missing", async () => {
+      const req = makeRequest("/api/history");
+      const res = await app.fetch(req, testEnv);
+      expect(res.status).toBe(400);
+    });
   });
 
-  describe("daily_note=true", () => {
-    it("returns at most 7 date groups by default", async () => {
-      const dateNodes = Array.from({ length: 10 }, (_, i) => {
-        const d = String(i + 1).padStart(2, "0");
-        return makeNode({ id: `date-${i}`, name: `[2026-01-${d}]`, priority: i });
-      });
-      mockGetNodes
-        .mockResolvedValueOnce(dateNodes)
-        .mockResolvedValue([makeNode()]);
+  describe("calendar destination", () => {
+    // Helper: days in `nonEmpty` return one child; everything else is empty (404 -> [])
+    function stubCalendar(nonEmpty: Record<string, WorkflowyNode[]>) {
+      mockGetCalendarNodes.mockImplementation((key: string) =>
+        Promise.resolve(nonEmpty[key] ?? [])
+      );
+      mockGetNode.mockImplementation((key: string) =>
+        Promise.resolve(makeNode({ id: `day-${key}` }))
+      );
+    }
 
-      const req = makeRequest("/api/history?parent_id=parent-1&daily_note=true");
+    it("returns up to 7 date groups, newest first, with ISO date and dateId", async () => {
+      const nonEmpty: Record<string, WorkflowyNode[]> = {};
+      for (let d = 4; d <= 10; d++) {
+        const key = `2026-01-${String(d).padStart(2, "0")}`;
+        nonEmpty[key] = [makeNode({ id: `item-${key}` })];
+      }
+      stubCalendar(nonEmpty);
+
+      const req = makeRequest("/api/history?calendar=true&local_date=2026-01-10");
+      const res = await app.fetch(req, testEnv);
+      const data = await res.json() as Array<{ date: string; dateId: string; items: WorkflowyNode[]; hasMore: boolean }>;
+
+      expect(res.status).toBe(200);
+      expect(data).toHaveLength(7);
+      expect(data[0].date).toBe("2026-01-10");
+      expect(data[6].date).toBe("2026-01-04");
+      expect(data[0].dateId).toBe("day-2026-01-10");
+      expect(data[0].items[0].id).toBe("item-2026-01-10");
+      expect(data[6].hasMore).toBe(true);
+    });
+
+    it("starts probing at local_date + 1 to cover timezone skew", async () => {
+      stubCalendar({ "2026-01-11": [makeNode({ id: "tomorrow-item" })] });
+
+      const req = makeRequest("/api/history?calendar=true&local_date=2026-01-10");
+      const res = await app.fetch(req, testEnv);
+      const data = await res.json() as Array<{ date: string }>;
+
+      expect(res.status).toBe(200);
+      expect(mockGetCalendarNodes).toHaveBeenCalledWith("2026-01-11");
+      expect(data.some((g) => g.date === "2026-01-11")).toBe(true);
+    });
+
+    it("skips empty days and stops at the scan cap with hasMore=false", async () => {
+      // Only 2 non-empty days within the 31-day window
+      stubCalendar({
+        "2026-01-08": [makeNode({ id: "a" })],
+        "2025-12-20": [makeNode({ id: "b" })],
+      });
+
+      const req = makeRequest("/api/history?calendar=true&local_date=2026-01-10");
+      const res = await app.fetch(req, testEnv);
+      const data = await res.json() as Array<{ date: string; hasMore: boolean }>;
+
+      expect(res.status).toBe(200);
+      expect(data).toHaveLength(2);
+      expect(data[0].date).toBe("2026-01-08");
+      expect(data[1].date).toBe("2025-12-20");
+      expect(data[1].hasMore).toBe(false);
+      expect(mockGetCalendarNodes).toHaveBeenCalledTimes(31);
+    });
+
+    it("stops probing early once 7 groups are found", async () => {
+      const nonEmpty: Record<string, WorkflowyNode[]> = {};
+      for (let d = 1; d <= 11; d++) {
+        const key = `2026-01-${String(d).padStart(2, "0")}`;
+        nonEmpty[key] = [makeNode()];
+      }
+      stubCalendar(nonEmpty);
+
+      const req = makeRequest("/api/history?calendar=true&local_date=2026-01-10");
       const res = await app.fetch(req, testEnv);
       const data = await res.json() as unknown[];
 
       expect(res.status).toBe(200);
-      expect(data.length).toBeLessThanOrEqual(7);
+      expect(data).toHaveLength(7);
+      expect(mockGetCalendarNodes.mock.calls.length).toBeLessThan(31);
     });
 
-    it("respects before_date query parameter", async () => {
-      const dateNodes = Array.from({ length: 10 }, (_, i) => {
-        const d = String(10 - i).padStart(2, "0");
-        return makeNode({ id: `date-${i}`, name: `[2026-01-${d}]`, priority: i });
+    it("paginates from the day before before_date", async () => {
+      stubCalendar({
+        "2026-01-05": [makeNode({ id: "at-boundary" })],
+        "2026-01-04": [makeNode({ id: "older" })],
       });
-      mockGetNodes
-        .mockResolvedValueOnce(dateNodes)
-        .mockResolvedValue([makeNode()]);
 
-      const req = makeRequest("/api/history?parent_id=parent-1&daily_note=true&before_date=2026-01-05");
+      const req = makeRequest("/api/history?calendar=true&before_date=2026-01-05");
       const res = await app.fetch(req, testEnv);
-      const data = await res.json() as unknown[];
+      const data = await res.json() as Array<{ date: string }>;
 
       expect(res.status).toBe(200);
-      expect(data).toHaveLength(4); // 2026-01-04, 03, 02, 01
+      expect(mockGetCalendarNodes).not.toHaveBeenCalledWith("2026-01-05");
+      expect(data).toHaveLength(1);
+      expect(data[0].date).toBe("2026-01-04");
     });
 
-    it("excludes date groups with no child nodes", async () => {
-      const dateNodes = [
-        makeNode({ id: "date-1", name: "[2026-01-02]", priority: 1 }),
-        makeNode({ id: "date-2", name: "[2026-01-01]", priority: 0 }),
-      ];
-      mockGetNodes
-        .mockResolvedValueOnce(dateNodes)
-        .mockResolvedValueOnce([makeNode()])
-        .mockResolvedValueOnce([]);
+    it("sets dateId to null when day node lookup fails", async () => {
+      mockGetCalendarNodes.mockImplementation((key: string) =>
+        Promise.resolve(key === "2026-01-10" ? [makeNode()] : [])
+      );
+      mockGetNode.mockRejectedValue(new Error("boom"));
 
-      const req = makeRequest("/api/history?parent_id=parent-1&daily_note=true");
+      const req = makeRequest("/api/history?calendar=true&local_date=2026-01-10");
       const res = await app.fetch(req, testEnv);
-      const data = await res.json() as Array<{ dateId: string }>;
+      const data = await res.json() as Array<{ dateId: string | null }>;
 
       expect(res.status).toBe(200);
       expect(data).toHaveLength(1);
-      expect(data[0].dateId).toBe("date-1");
+      expect(data[0].dateId).toBeNull();
     });
-  });
 
-  it("returns 400 when parent_id is missing", async () => {
-    const req = makeRequest("/api/history?daily_note=true");
-    const res = await app.fetch(req, testEnv);
-    expect(res.status).toBe(400);
+    it("returns empty array when no notes exist in the scan window", async () => {
+      stubCalendar({});
+
+      const req = makeRequest("/api/history?calendar=true&local_date=2026-01-10");
+      const res = await app.fetch(req, testEnv);
+      const data = await res.json() as unknown[];
+
+      expect(res.status).toBe(200);
+      expect(data).toEqual([]);
+    });
+
+    it("returns 400 when neither local_date nor before_date is given", async () => {
+      const req = makeRequest("/api/history?calendar=true");
+      const res = await app.fetch(req, testEnv);
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for malformed date", async () => {
+      const req = makeRequest("/api/history?calendar=true&local_date=today");
+      const res = await app.fetch(req, testEnv);
+      expect(res.status).toBe(400);
+    });
   });
 });
 

--- a/src/test/history.test.ts
+++ b/src/test/history.test.ts
@@ -1,78 +1,58 @@
 import { describe, it, expect } from "vitest";
-import { filterDailyNotesByBeforeDate, parseDateFromNodeName } from "../api/history";
-import type { WorkflowyNode } from "../types";
+import { addDays, dateKeysBack } from "../api/history";
 
-function makeNode(overrides: Partial<WorkflowyNode> = {}): WorkflowyNode {
-  return {
-    id: "node-1",
-    name: "Test Node",
-    note: null,
-    priority: 0,
-    createdAt: 0,
-    modifiedAt: 0,
-    completedAt: null,
-    ...overrides,
-  };
-}
-
-describe("parseDateFromNodeName", () => {
-  it("parses [YYYY-MM-DD] format", () => {
-    expect(parseDateFromNodeName("[2026-05-27]")).toBe("2026-05-27");
+describe("addDays", () => {
+  it("adds days within the same month", () => {
+    expect(addDays("2026-05-10", 3)).toBe("2026-05-13");
   });
 
-  it("parses Workflowy format (Mon, Jan 1, 2026)", () => {
-    expect(parseDateFromNodeName("Tue, May 27, 2026")).toBe("2026-05-27");
+  it("subtracts days with negative n", () => {
+    expect(addDays("2026-05-10", -3)).toBe("2026-05-07");
   });
 
-  it("returns null for unrecognized format", () => {
-    expect(parseDateFromNodeName("some random text")).toBeNull();
+  it("crosses month boundary forward", () => {
+    expect(addDays("2026-05-31", 1)).toBe("2026-06-01");
   });
 
-  it("returns null for empty string", () => {
-    expect(parseDateFromNodeName("")).toBeNull();
+  it("crosses month boundary backward", () => {
+    expect(addDays("2026-05-01", -1)).toBe("2026-04-30");
+  });
+
+  it("crosses year boundary backward", () => {
+    expect(addDays("2026-01-01", -1)).toBe("2025-12-31");
+  });
+
+  it("handles leap year", () => {
+    expect(addDays("2024-03-01", -1)).toBe("2024-02-29");
+  });
+
+  it("returns same date for n=0", () => {
+    expect(addDays("2026-05-10", 0)).toBe("2026-05-10");
   });
 });
 
-describe("filterDailyNotesByBeforeDate", () => {
-  const nodes = [
-    makeNode({ id: "1", name: "[2026-05-27]", priority: 1 }),
-    makeNode({ id: "2", name: "[2026-05-26]", priority: 2 }),
-    makeNode({ id: "3", name: "[2026-05-25]", priority: 3 }),
-    makeNode({ id: "4", name: "[2026-05-24]", priority: 4 }),
-    makeNode({ id: "5", name: "[2026-05-23]", priority: 5 }),
-    makeNode({ id: "6", name: "[2026-05-22]", priority: 6 }),
-    makeNode({ id: "7", name: "[2026-05-21]", priority: 7 }),
-    makeNode({ id: "8", name: "[2026-05-20]", priority: 8 }),
-    makeNode({ id: "9", name: "not a date node", priority: 9 }),
-  ];
-
-  it("returns latest 7 days when no before_date specified", () => {
-    const result = filterDailyNotesByBeforeDate(nodes, null);
-    expect(result).toHaveLength(7);
-    expect(result[0].id).toBe("1");
-    expect(result[6].id).toBe("7");
+describe("dateKeysBack", () => {
+  it("returns consecutive date keys going backward from start", () => {
+    expect(dateKeysBack("2026-05-10", 3)).toEqual([
+      "2026-05-10",
+      "2026-05-09",
+      "2026-05-08",
+    ]);
   });
 
-  it("returns up to 7 days strictly older than before_date", () => {
-    const result = filterDailyNotesByBeforeDate(nodes, "2026-05-25");
-    expect(result).toHaveLength(5);
-    expect(result[0].id).toBe("4"); // 2026-05-24
-    expect(result[4].id).toBe("8"); // 2026-05-20
+  it("crosses month boundary", () => {
+    expect(dateKeysBack("2026-06-01", 3)).toEqual([
+      "2026-06-01",
+      "2026-05-31",
+      "2026-05-30",
+    ]);
   });
 
-  it("excludes nodes without parseable dates", () => {
-    const result = filterDailyNotesByBeforeDate(nodes, null);
-    expect(result.every((n) => n.id !== "9")).toBe(true);
+  it("returns single key for count=1", () => {
+    expect(dateKeysBack("2026-05-10", 1)).toEqual(["2026-05-10"]);
   });
 
-  it("returns fewer than 7 if not enough nodes exist", () => {
-    const few = nodes.slice(0, 3);
-    const result = filterDailyNotesByBeforeDate(few, null);
-    expect(result).toHaveLength(3);
-  });
-
-  it("returns empty array when before_date is older than all nodes", () => {
-    const result = filterDailyNotesByBeforeDate(nodes, "2026-05-01");
-    expect(result).toHaveLength(0);
+  it("returns empty array for count=0", () => {
+    expect(dateKeysBack("2026-05-10", 0)).toEqual([]);
   });
 });

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -2,9 +2,62 @@ import { describe, it, expect } from "vitest";
 
 // Import utils - we'll need to handle ES modules
 // Since utils.js uses DOM APIs, we need jsdom environment (configured in vitest.config.ts)
-const { applyTemplate, parseContent, escapeRegex, escapeHtml, stripHtml, sanitizeHtml } = await import(
+const { applyTemplate, parseContent, escapeRegex, escapeHtml, stripHtml, sanitizeHtml, migrateSettings } = await import(
   "../../public/scripts/utils.js"
 );
+
+describe("migrateSettings", () => {
+  it("converts dailyNoteEnabled:true destination to calendar type without nodeId", () => {
+    const { settings, changed } = migrateSettings({
+      destinations: [
+        { id: "d1", nodeId: "n1", name: "Journal", dailyNoteEnabled: true, defaultText: "" },
+      ],
+      selectedDestinationId: "d1",
+    });
+    expect(changed).toBe(true);
+    expect(settings.destinations[0]).toEqual({
+      id: "d1",
+      type: "calendar",
+      name: "Journal",
+      defaultText: "",
+    });
+  });
+
+  it("converts dailyNoteEnabled:false destination to node type keeping nodeId", () => {
+    const { settings, changed } = migrateSettings({
+      destinations: [
+        { id: "d1", nodeId: "n1", name: "Inbox", dailyNoteEnabled: false, defaultText: "x" },
+      ],
+      selectedDestinationId: "d1",
+    });
+    expect(changed).toBe(true);
+    expect(settings.destinations[0]).toEqual({
+      id: "d1",
+      type: "node",
+      nodeId: "n1",
+      name: "Inbox",
+      defaultText: "x",
+    });
+  });
+
+  it("leaves already-migrated destinations untouched", () => {
+    const input = {
+      destinations: [
+        { id: "d1", type: "calendar", name: "Daily", defaultText: "" },
+        { id: "d2", type: "node", nodeId: "n2", name: "Inbox", defaultText: "" },
+      ],
+      selectedDestinationId: "d1",
+    };
+    const { settings, changed } = migrateSettings(input);
+    expect(changed).toBe(false);
+    expect(settings).toEqual(input);
+  });
+
+  it("handles empty or missing destinations", () => {
+    expect(migrateSettings({ destinations: [] }).changed).toBe(false);
+    expect(migrateSettings({}).changed).toBe(false);
+  });
+});
 
 describe("applyTemplate", () => {
   const fixedDate = new Date(2026, 1, 14, 9, 30, 45); // 2026-02-14 09:30:45

--- a/src/test/workflowy-v1.test.ts
+++ b/src/test/workflowy-v1.test.ts
@@ -85,48 +85,74 @@ describe("WorkflowyClient", () => {
     });
   });
 
-  describe("findDailyNote", () => {
-    it("finds node matching ISO date string", async () => {
-      const nodes = [makeNode({ id: "daily-1", name: "[2026-02-14]" })];
+  describe("getCalendarNodes", () => {
+    it("returns nodes sorted by priority", async () => {
+      const nodes = [
+        makeNode({ id: "b", priority: 2 }),
+        makeNode({ id: "a", priority: 1 }),
+      ];
       mockFetch.mockReturnValue(okResponse({ nodes }));
 
-      const result = await client.findDailyNote("parent-1", "2026-02-14");
-      expect(result?.id).toBe("daily-1");
+      const result = await client.getCalendarNodes("2026-02-14");
+      expect(result[0].id).toBe("a");
+      expect(result[1].id).toBe("b");
     });
 
-    it("finds node matching Workflowy date format", async () => {
-      const nodes = [makeNode({ id: "daily-1", name: "Sat, Feb 14, 2026" })];
-      mockFetch.mockReturnValue(okResponse({ nodes }));
-
-      const result = await client.findDailyNote("parent-1", "2026-02-14");
-      expect(result?.id).toBe("daily-1");
+    it("returns empty array on 404 (calendar node not created yet)", async () => {
+      mockFetch.mockReturnValue(
+        Promise.resolve(
+          new Response(JSON.stringify({ code: "not_found" }), { status: 404 })
+        )
+      );
+      const result = await client.getCalendarNodes("1999-01-05");
+      expect(result).toEqual([]);
     });
 
-    it("returns null when no matching node", async () => {
+    it("throws on other HTTP errors", async () => {
+      mockFetch.mockReturnValue(
+        Promise.resolve(new Response("Server Error", { status: 500 }))
+      );
+      await expect(client.getCalendarNodes("2026-02-14")).rejects.toThrow("500");
+    });
+
+    it("calls correct endpoint with date key as parent_id", async () => {
       mockFetch.mockReturnValue(okResponse({ nodes: [] }));
-      const result = await client.findDailyNote("parent-1", "2026-02-14");
-      expect(result).toBeNull();
+      await client.getCalendarNodes("2026-02-14");
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("parent_id=2026-02-14"),
+        expect.any(Object)
+      );
     });
   });
 
-  describe("getOrCreateDailyNote", () => {
-    it("returns existing node ID if found", async () => {
-      const nodes = [makeNode({ id: "existing-daily", name: "[2026-02-14]" })];
-      mockFetch.mockReturnValue(okResponse({ nodes }));
-
-      const id = await client.getOrCreateDailyNote("parent-1", "2026-02-14");
-      expect(id).toBe("existing-daily");
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+  describe("getNode", () => {
+    it("returns the node for a date key", async () => {
+      mockFetch.mockReturnValue(
+        okResponse({ node: makeNode({ id: "day-node-id" }) })
+      );
+      const result = await client.getNode("2026-02-14");
+      expect(result?.id).toBe("day-node-id");
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/nodes/2026-02-14"),
+        expect.any(Object)
+      );
     });
 
-    it("creates node if not found and returns new ID", async () => {
-      mockFetch
-        .mockReturnValueOnce(okResponse({ nodes: [] }))
-        .mockReturnValueOnce(okResponse({ item_id: "new-daily" }));
+    it("returns null on 404", async () => {
+      mockFetch.mockReturnValue(
+        Promise.resolve(
+          new Response(JSON.stringify({ code: "not_found" }), { status: 404 })
+        )
+      );
+      const result = await client.getNode("1999-01-05");
+      expect(result).toBeNull();
+    });
 
-      const id = await client.getOrCreateDailyNote("parent-1", "2026-02-14");
-      expect(id).toBe("new-daily");
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+    it("throws on other HTTP errors", async () => {
+      mockFetch.mockReturnValue(
+        Promise.resolve(new Response("Server Error", { status: 500 }))
+      );
+      await expect(client.getNode("2026-02-14")).rejects.toThrow("500");
     });
   });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,8 @@
 export interface Destination {
   id: string;
-  nodeId: string;
+  type: "node" | "calendar";
+  nodeId?: string;
   name: string;
-  dailyNoteEnabled: boolean;
   defaultText: string;
 }
 
@@ -28,6 +28,17 @@ export interface WorkflowyNodesResponse {
 
 export interface CreateNodeResponse {
   item_id: string;
+}
+
+export interface WorkflowyNodeResponse {
+  node: WorkflowyNode;
+}
+
+export interface HistoryGroup {
+  date: string | null;
+  dateId: string | null;
+  items: WorkflowyNode[];
+  hasMore: boolean;
 }
 
 export interface Env {


### PR DESCRIPTION
## Summary

- デイリーノートを独自実装（任意ノード配下にプレーンテキストの `[YYYY-MM-DD]` ノードを自作）から、Workflowy公式APIのネイティブカレンダーに全面移行
- 独自実装の日付ノードはWorkflowy本体でDay Nodeとして認識されず、WF側でtodayを開くと別ノードが作られて二重化する問題を根本解決

## Changes

### 送信
- Calendar型destinationは `parent_id="today"` でPOST 1回のみ（Day NodeはWF側がオンデマンド作成）
- 従来の「子ノード全取得→部分一致検索→日付ノード作成」（最大3リクエスト）を削除

### 履歴
- 日付キー（`YYYY-MM-DD`）を7日ずつ並列でプローブし、7グループ集まるか31日/リクエストで打ち切る方式に変更（Workersサブリクエスト上限50を考慮）
- カレンダー階層のユーザー設定（月/週/フラット）に依存しない
- 404 = その日のノート無し。日付見出しのWFリンク・グループ削除用の `dateId` は `GET /nodes/:id` に日付キーを渡して解決
- クライアントとWFアカウントのTZずれに備え、初回スキャンは `local_date + 1日` から開始

### データモデル / UI
- `Destination` の `dailyNoteEnabled` フラグを `type: "node" | "calendar"` に置換。旧設定はLocalStorage読み込み時に `migrateSettings` で自動変換（旧履歴キャッシュは破棄）
- destination追加UIに種別ラジオを追加。Calendar型はノード選択・名前入力とも不要（名前は "Daily Note" 固定）
- Calendar型destinationにはカレンダーアイコンの目印を表示（ツールバー・ドロップダウン・設定一覧）

### 削除
- `findDailyNote` / `getOrCreateDailyNote` / `parseDateFromNodeName` / `filterDailyNotesByBeforeDate` / フロントの `parseDateText`（履歴グループのキーがISO日付そのものになり、ノード名パースが不要に）

### 互換性の注意
- 旧実装が作った `[YYYY-MM-DD]` ノードは履歴に表示されなくなる（WF公式のカレンダー移行ツールで統合可能、README に記載）

## Test Plan

- [x] 単体テスト84件パス（`npm run test:run`）
- [x] `npm run typecheck` パス
- [x] 実APIでE2E検証: カレンダー宛送信がWFネイティブのtodayに着地・二重化なし、履歴7グループ・dateId解決・`before_date` ページング・不正日付400、node型destinationの送信/履歴が無変化
- [x] ブラウザで旧設定の自動マイグレーションとUI（種別ラジオ、アイコン表示）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)