### PR TITLE
fix(pwa): precache utils.js for offline use

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,10 @@
-const CACHE_VERSION = "0.0.2";
+const CACHE_VERSION = "0.0.3";
 const CACHE_NAME = `jotflowy-${CACHE_VERSION}`;
 const STATIC_ASSETS = [
   "/",
   "/styles/main.css",
   "/scripts/client.js",
+  "/scripts/utils.js",
   "/manifest.json",
 ];
 


### PR DESCRIPTION
## Summary

client.jsがESモジュールとしてimportしているutils.jsがService WorkerのSTATIC_ASSETSに含まれておらず、オフライン時にキャッシュへフォールバックした際、アプリが起動できない既存バグを修正します。キャッシュバージョンを0.0.3に上げ、既存インストールにも新しいアセット一覧が行き渡るようにしています。

## Test plan

- 既存テスト・typecheckに影響なし（sw.jsのみの変更）
- デプロイ後、DevToolsのNetworkでofflineにしてリロードし、画面が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)